### PR TITLE
Content Block Message Center Support

### DIFF
--- a/Braze Demo.xcodeproj/project.pbxproj
+++ b/Braze Demo.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		7F87D4AA24B0500200ED0A86 /* AppboySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F87D4A924B0500200ED0A86 /* AppboySettingsViewController.swift */; };
 		7F87D4AC24B2709400ED0A86 /* ShoppingCartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F87D4AB24B2709400ED0A86 /* ShoppingCartViewController.swift */; };
 		7F87D4AE24B2A24B00ED0A86 /* TextField_Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F87D4AD24B2A24B00ED0A86 /* TextField_Util.swift */; };
+		7F8AF00725253501006F478B /* APITriggeredCampaignRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8AF00625253501006F478B /* APITriggeredCampaignRequest.swift */; };
+		7F8AF00C25253521006F478B /* ContentBlockRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8AF00B25253521006F478B /* ContentBlockRequest.swift */; };
 		7F8FFC1A24EC7EB50082C71B /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8FFC1924EC7EB50082C71B /* APIRequest.swift */; };
 		7F9DCBC424AD786A00E8D207 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7F9DCBC324AD786A00E8D207 /* LaunchScreen.storyboard */; };
 		7F9DCBC624AD787A00E8D207 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7F9DCBC524AD787A00E8D207 /* Main.storyboard */; };
@@ -85,6 +87,8 @@
 		7F87D4A924B0500200ED0A86 /* AppboySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppboySettingsViewController.swift; sourceTree = "<group>"; };
 		7F87D4AB24B2709400ED0A86 /* ShoppingCartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingCartViewController.swift; sourceTree = "<group>"; };
 		7F87D4AD24B2A24B00ED0A86 /* TextField_Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextField_Util.swift; sourceTree = "<group>"; };
+		7F8AF00625253501006F478B /* APITriggeredCampaignRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITriggeredCampaignRequest.swift; sourceTree = "<group>"; };
+		7F8AF00B25253521006F478B /* ContentBlockRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockRequest.swift; sourceTree = "<group>"; };
 		7F8FFC1924EC7EB50082C71B /* APIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
 		7F9DCBC324AD786A00E8D207 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		7F9DCBC524AD787A00E8D207 /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
@@ -195,6 +199,15 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
+		7F8AF0132525353D006F478B /* API Requests */ = {
+			isa = PBXGroup;
+			children = (
+				7F8AF00625253501006F478B /* APITriggeredCampaignRequest.swift */,
+				7F8AF00B25253521006F478B /* ContentBlockRequest.swift */,
+			);
+			path = "API Requests";
+			sourceTree = "<group>";
+		};
 		7F9DCBC124AD784700E8D207 /* Storyboard */ = {
 			isa = PBXGroup;
 			children = (
@@ -222,6 +235,7 @@
 				7F9DCBC724AD79AC00E8D207 /* LocalDataCoordinator.swift */,
 				7FE763ED24CBCDB10017C5D2 /* HomeListOperationQueue.swift */,
 				7F8FFC1924EC7EB50082C71B /* APIRequest.swift */,
+				7F8AF0132525353D006F478B /* API Requests */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -558,6 +572,7 @@
 				7FDFA26724B688E900E3B132 /* MessageCenterViewController.swift in Sources */,
 				7F9DCBCC24AD79C300E8D207 /* AppboyManager.swift in Sources */,
 				7FDFA26F24B68DC000E3B132 /* MessageCenterTableViewCell.swift in Sources */,
+				7F8AF00725253501006F478B /* APITriggeredCampaignRequest.swift in Sources */,
 				7FBDD49324AD711E00EC0983 /* Braze Demo.xcdatamodeld in Sources */,
 				7FBDD48924AD711E00EC0983 /* AppDelegate.swift in Sources */,
 				7FF1ADBA24C0B67400AF09F0 /* MessageCenterDetailViewController.swift in Sources */,
@@ -568,6 +583,7 @@
 				7F87D4AC24B2709400ED0A86 /* ShoppingCartViewController.swift in Sources */,
 				7FCFB98F24C91F0D001AA381 /* BannerAdCollectionViewCell.swift in Sources */,
 				7F754FC3250C2F8000CD7B45 /* RemoteStorage.swift in Sources */,
+				7F8AF00C25253521006F478B /* ContentBlockRequest.swift in Sources */,
 				7F9DCBCF24AD7A0400E8D207 /* ImageCache.swift in Sources */,
 				7FCFB97B24C35EBA001AA381 /* ContentCardWebView.swift in Sources */,
 				7F87D4AA24B0500200ED0A86 /* AppboySettingsViewController.swift in Sources */,

--- a/Braze Demo/API/API Requests/APITriggeredCampaignRequest.swift
+++ b/Braze Demo/API/API Requests/APITriggeredCampaignRequest.swift
@@ -1,0 +1,18 @@
+struct APITriggeredCampaignRequest: APIRequest {
+  private(set) var method: HTTPMethod = .post
+  private(set) var path: String = "/campaigns/trigger/send"
+  private(set) var parameters: [String : String]?
+  private(set) var body: [String : Any]?
+  private(set) var additionalHeaders: [String : String]?
+  
+  init(campaignId: String, campaignAPIKey: String, userId: String, triggerProperties: [String: Any]) {
+    var body = [String: Any]()
+    body["campaign_id"] = campaignId
+    body["trigger_properties"] = triggerProperties
+    body["broadcast"] = false
+    body["recipients"] = [["external_user_id": userId]]
+    
+    self.body = body
+    self.additionalHeaders = ["Authorization": "Bearer \(campaignAPIKey)"]
+  }
+}

--- a/Braze Demo/API/API Requests/ContentBlockRequest.swift
+++ b/Braze Demo/API/API Requests/ContentBlockRequest.swift
@@ -12,6 +12,8 @@ struct ContentBlockRequest: APIRequest {
 }
 
 // MARK: - Content Block
+///Content Blocks allow users to manage reusable, cross-channel content in a single, centralized location. A custom object is used in the demo is for HTML strings larger than 2kb.
 struct ContentBlock: Codable {
   let content: String?
 }
+//For more info: https://www.braze.com/docs/user_guide/engagement_tools/templates_and_media/content_blocks/ and https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/get_see_email_content_blocks_information/

--- a/Braze Demo/API/API Requests/ContentBlockRequest.swift
+++ b/Braze Demo/API/API Requests/ContentBlockRequest.swift
@@ -12,7 +12,7 @@ struct ContentBlockRequest: APIRequest {
 }
 
 // MARK: - Content Block
-///Content Blocks allow users to manage reusable, cross-channel content in a single, centralized location. A custom object is used in the demo is for HTML strings larger than 2kb.
+///Content Blocks allow users to manage reusable, cross-channel content in a single, centralized location. A custom object is used in the demo for HTML strings larger than 2kb.
 struct ContentBlock: Codable {
   let content: String?
 }

--- a/Braze Demo/API/API Requests/ContentBlockRequest.swift
+++ b/Braze Demo/API/API Requests/ContentBlockRequest.swift
@@ -1,0 +1,17 @@
+struct ContentBlockRequest: APIRequest {
+  private(set) var method: HTTPMethod = .get
+  private(set) var path: String = "/content_blocks/info"
+  private(set) var parameters: [String : String]?
+  private(set) var body: [String : Any]?
+  private(set) var additionalHeaders: [String : String]?
+  
+  init(contentBlockAPIKey: String, parameters: [String: String]?) {
+    self.parameters = parameters
+    self.additionalHeaders = ["Authorization": "Bearer \(contentBlockAPIKey)"]
+  }
+}
+
+// MARK: - Content Block
+struct ContentBlock: Codable {
+  let content: String?
+}

--- a/Braze Demo/Model/ContentCardData.swift
+++ b/Braze Demo/Model/ContentCardData.swift
@@ -63,6 +63,7 @@ enum ContentCardKey: String {
   case url
   case discountPercentage = "discount_percentage"
   case tags = "tile_tags"
+  case contentBlock = "content_block_id"
 }
 
 // MARK: - ContentCardClassType

--- a/Braze Demo/Model/Message.swift
+++ b/Braze Demo/Model/Message.swift
@@ -14,14 +14,15 @@ protocol Message: ContentCardable {
 // MARK: - WebView Message
 ///The object that is responsible for working with the `message_webview` class_type from the Braze dashboard. When this message is clicked on in the Message Center, it will open to a WKWebView that loads either an html string or a url string.
 struct WebViewMessage: Message {
-  private enum WebViewType {
+  enum WebViewType {
     case html(String)
     case url(String)
+    case contentBlock(String)
     case none
   }
   
   let contentCardData: ContentCardData?
-  private let webViewType: WebViewType
+  let webViewType: WebViewType
   let messageHeader: String?
   let messageTitle: String?
   let imageUrl: String?
@@ -36,6 +37,8 @@ extension WebViewMessage {
       return htmlString
     case .url(let urlString):
       return urlString
+    case .contentBlock(let contentBlockId):
+      return contentBlockId
     default: return ""
     }
   }
@@ -61,6 +64,8 @@ extension WebViewMessage {
       webViewType = .html(htmlString)
     } else if let urlString = extras[ContentCardKey.url.rawValue] as? String {
       webViewType = .url(urlString)
+    } else if let contentBlockId = extras[ContentCardKey.contentBlock.rawValue] as? String {
+      webViewType = .contentBlock(contentBlockId)
     }
     
     let contentCardData = ContentCardData(contentCardId: contentCardId, contentCardClassType: contentCardClassType, createdAt: createdAt, isDismissable: isDismissable)

--- a/Braze Demo/Storyboard/Main.storyboard
+++ b/Braze Demo/Storyboard/Main.storyboard
@@ -584,10 +584,10 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wRw-av-1kd" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="707"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="767.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="dbx-K3-JkQ">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="707"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="767.5"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gKa-mO-wyP" userLabel="User Id">
                                                         <rect key="frame" x="0.0" y="0.0" width="414" height="116.5"/>
@@ -786,7 +786,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="O9G-c5-mfd" userLabel="Attribute">
-                                                        <rect key="frame" x="0.0" y="587" width="414" height="120"/>
+                                                        <rect key="frame" x="0.0" y="587" width="414" height="180.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Message Center Content Card" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e4N-Ry-zkx">
                                                                 <rect key="frame" x="87" y="20" width="240" height="20.5"/>
@@ -794,103 +794,137 @@
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="oaT-Cl-Wj8">
-                                                                <rect key="frame" x="20" y="50.5" width="374" height="50"/>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="isn-Vz-XDa">
+                                                                <rect key="frame" x="20" y="50.5" width="374" height="110"/>
                                                                 <subviews>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kQa-tM-gIY">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="118" height="50"/>
-                                                                        <color key="backgroundColor" systemColor="systemGrayColor"/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="height" constant="50" id="c8f-oW-2Jy"/>
-                                                                        </constraints>
-                                                                        <state key="normal" title="FULL PAGE">
-                                                                            <color key="titleColor" systemColor="systemBackgroundColor"/>
-                                                                        </state>
-                                                                        <userDefinedRuntimeAttributes>
-                                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                                                <integer key="value" value="5"/>
-                                                                            </userDefinedRuntimeAttribute>
-                                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
-                                                                                <real key="value" value="0.5"/>
-                                                                            </userDefinedRuntimeAttribute>
-                                                                            <userDefinedRuntimeAttribute type="size" keyPath="layer.shadowOffset">
-                                                                                <size key="value" width="0.0" height="2"/>
-                                                                            </userDefinedRuntimeAttribute>
-                                                                        </userDefinedRuntimeAttributes>
-                                                                        <connections>
-                                                                            <action selector="messageCenterCampaignButtonPressed:" destination="MAV-8o-BCL" eventType="touchUpInside" id="PLc-jy-78F"/>
-                                                                        </connections>
-                                                                    </button>
-                                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ERL-jE-cPd">
-                                                                        <rect key="frame" x="128" y="0.0" width="118" height="50"/>
-                                                                        <color key="backgroundColor" systemColor="systemGrayColor"/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="height" constant="50" id="CPf-sl-Aw7"/>
-                                                                        </constraints>
-                                                                        <state key="normal" title="HTML">
-                                                                            <color key="titleColor" systemColor="systemBackgroundColor"/>
-                                                                        </state>
-                                                                        <userDefinedRuntimeAttributes>
-                                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                                                <integer key="value" value="5"/>
-                                                                            </userDefinedRuntimeAttribute>
-                                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
-                                                                                <real key="value" value="0.5"/>
-                                                                            </userDefinedRuntimeAttribute>
-                                                                            <userDefinedRuntimeAttribute type="size" keyPath="layer.shadowOffset">
-                                                                                <size key="value" width="0.0" height="2"/>
-                                                                            </userDefinedRuntimeAttribute>
-                                                                        </userDefinedRuntimeAttributes>
-                                                                        <connections>
-                                                                            <action selector="messageCenterCampaignButtonPressed:" destination="MAV-8o-BCL" eventType="touchUpInside" id="ozq-aI-1D7"/>
-                                                                        </connections>
-                                                                    </button>
-                                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jLM-aT-XDJ">
-                                                                        <rect key="frame" x="256" y="0.0" width="118" height="50"/>
-                                                                        <color key="backgroundColor" systemColor="systemGrayColor"/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="height" constant="50" id="n0P-pk-UUZ"/>
-                                                                        </constraints>
-                                                                        <state key="normal" title="URL">
-                                                                            <color key="titleColor" systemColor="systemBackgroundColor"/>
-                                                                        </state>
-                                                                        <userDefinedRuntimeAttributes>
-                                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                                                <integer key="value" value="5"/>
-                                                                            </userDefinedRuntimeAttribute>
-                                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
-                                                                                <real key="value" value="0.5"/>
-                                                                            </userDefinedRuntimeAttribute>
-                                                                            <userDefinedRuntimeAttribute type="size" keyPath="layer.shadowOffset">
-                                                                                <size key="value" width="0.0" height="2"/>
-                                                                            </userDefinedRuntimeAttribute>
-                                                                        </userDefinedRuntimeAttributes>
-                                                                        <connections>
-                                                                            <action selector="messageCenterCampaignButtonPressed:" destination="MAV-8o-BCL" eventType="touchUpInside" id="SA0-PZ-4K5"/>
-                                                                        </connections>
-                                                                    </button>
+                                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="oaT-Cl-Wj8">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="374" height="50"/>
+                                                                        <subviews>
+                                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kQa-tM-gIY">
+                                                                                <rect key="frame" x="0.0" y="0.0" width="182" height="50"/>
+                                                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="height" constant="50" id="c8f-oW-2Jy"/>
+                                                                                </constraints>
+                                                                                <state key="normal" title="Full Page">
+                                                                                    <color key="titleColor" systemColor="systemBackgroundColor"/>
+                                                                                </state>
+                                                                                <userDefinedRuntimeAttributes>
+                                                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                                        <integer key="value" value="5"/>
+                                                                                    </userDefinedRuntimeAttribute>
+                                                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
+                                                                                        <real key="value" value="0.5"/>
+                                                                                    </userDefinedRuntimeAttribute>
+                                                                                    <userDefinedRuntimeAttribute type="size" keyPath="layer.shadowOffset">
+                                                                                        <size key="value" width="0.0" height="2"/>
+                                                                                    </userDefinedRuntimeAttribute>
+                                                                                </userDefinedRuntimeAttributes>
+                                                                                <connections>
+                                                                                    <action selector="messageCenterCampaignButtonPressed:" destination="MAV-8o-BCL" eventType="touchUpInside" id="PLc-jy-78F"/>
+                                                                                </connections>
+                                                                            </button>
+                                                                            <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ERL-jE-cPd">
+                                                                                <rect key="frame" x="192" y="0.0" width="182" height="50"/>
+                                                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="height" constant="50" id="CPf-sl-Aw7"/>
+                                                                                </constraints>
+                                                                                <state key="normal" title="HTML">
+                                                                                    <color key="titleColor" systemColor="systemBackgroundColor"/>
+                                                                                </state>
+                                                                                <userDefinedRuntimeAttributes>
+                                                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                                        <integer key="value" value="5"/>
+                                                                                    </userDefinedRuntimeAttribute>
+                                                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
+                                                                                        <real key="value" value="0.5"/>
+                                                                                    </userDefinedRuntimeAttribute>
+                                                                                    <userDefinedRuntimeAttribute type="size" keyPath="layer.shadowOffset">
+                                                                                        <size key="value" width="0.0" height="2"/>
+                                                                                    </userDefinedRuntimeAttribute>
+                                                                                </userDefinedRuntimeAttributes>
+                                                                                <connections>
+                                                                                    <action selector="messageCenterCampaignButtonPressed:" destination="MAV-8o-BCL" eventType="touchUpInside" id="ozq-aI-1D7"/>
+                                                                                </connections>
+                                                                            </button>
+                                                                        </subviews>
+                                                                    </stackView>
+                                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="VnX-W2-Kgh">
+                                                                        <rect key="frame" x="0.0" y="60" width="374" height="50"/>
+                                                                        <subviews>
+                                                                            <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8A4-we-RMX">
+                                                                                <rect key="frame" x="0.0" y="0.0" width="182" height="50"/>
+                                                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="height" constant="50" id="ySp-Gy-hgl"/>
+                                                                                </constraints>
+                                                                                <state key="normal" title="URL">
+                                                                                    <color key="titleColor" systemColor="systemBackgroundColor"/>
+                                                                                </state>
+                                                                                <userDefinedRuntimeAttributes>
+                                                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                                        <integer key="value" value="5"/>
+                                                                                    </userDefinedRuntimeAttribute>
+                                                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
+                                                                                        <real key="value" value="0.5"/>
+                                                                                    </userDefinedRuntimeAttribute>
+                                                                                    <userDefinedRuntimeAttribute type="size" keyPath="layer.shadowOffset">
+                                                                                        <size key="value" width="0.0" height="2"/>
+                                                                                    </userDefinedRuntimeAttribute>
+                                                                                </userDefinedRuntimeAttributes>
+                                                                                <connections>
+                                                                                    <action selector="messageCenterCampaignButtonPressed:" destination="MAV-8o-BCL" eventType="touchUpInside" id="ifz-Aw-41S"/>
+                                                                                </connections>
+                                                                            </button>
+                                                                            <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jQf-Te-9b8">
+                                                                                <rect key="frame" x="192" y="0.0" width="182" height="50"/>
+                                                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="height" constant="50" id="Wyb-mu-F2a"/>
+                                                                                </constraints>
+                                                                                <state key="normal" title="Content Block">
+                                                                                    <color key="titleColor" systemColor="systemBackgroundColor"/>
+                                                                                </state>
+                                                                                <userDefinedRuntimeAttributes>
+                                                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                                        <integer key="value" value="5"/>
+                                                                                    </userDefinedRuntimeAttribute>
+                                                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
+                                                                                        <real key="value" value="0.5"/>
+                                                                                    </userDefinedRuntimeAttribute>
+                                                                                    <userDefinedRuntimeAttribute type="size" keyPath="layer.shadowOffset">
+                                                                                        <size key="value" width="0.0" height="2"/>
+                                                                                    </userDefinedRuntimeAttribute>
+                                                                                </userDefinedRuntimeAttributes>
+                                                                                <connections>
+                                                                                    <action selector="messageCenterCampaignButtonPressed:" destination="MAV-8o-BCL" eventType="touchUpInside" id="FGZ-bA-NGC"/>
+                                                                                </connections>
+                                                                            </button>
+                                                                        </subviews>
+                                                                    </stackView>
                                                                 </subviews>
                                                             </stackView>
                                                         </subviews>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="120" id="Tae-j6-ILs"/>
+                                                            <constraint firstItem="isn-Vz-XDa" firstAttribute="top" secondItem="e4N-Ry-zkx" secondAttribute="bottom" constant="10" id="0Ya-7x-GCp"/>
+                                                            <constraint firstAttribute="bottom" secondItem="isn-Vz-XDa" secondAttribute="bottom" constant="20" id="6CI-nH-5Bc"/>
+                                                            <constraint firstItem="e4N-Ry-zkx" firstAttribute="centerX" secondItem="O9G-c5-mfd" secondAttribute="centerX" id="JLv-Yz-Hub"/>
                                                             <constraint firstItem="e4N-Ry-zkx" firstAttribute="top" secondItem="O9G-c5-mfd" secondAttribute="top" constant="20" id="Yym-YD-3Ae"/>
-                                                            <constraint firstItem="e4N-Ry-zkx" firstAttribute="centerX" secondItem="oaT-Cl-Wj8" secondAttribute="centerX" id="wLf-g0-7DI"/>
-                                                            <constraint firstItem="oaT-Cl-Wj8" firstAttribute="top" secondItem="e4N-Ry-zkx" secondAttribute="bottom" constant="10" id="z8w-UH-LHt"/>
                                                         </constraints>
                                                     </view>
                                                 </subviews>
                                                 <constraints>
                                                     <constraint firstItem="DtX-bu-IVY" firstAttribute="leading" secondItem="YlC-av-iZJ" secondAttribute="leading" id="1z0-nQ-JXs"/>
+                                                    <constraint firstItem="isn-Vz-XDa" firstAttribute="leading" secondItem="YlC-av-iZJ" secondAttribute="leading" id="2Lj-st-w7G"/>
                                                     <constraint firstItem="Sbs-Jr-KdF" firstAttribute="trailing" secondItem="YlC-av-iZJ" secondAttribute="trailing" id="88m-Hu-wHi"/>
                                                     <constraint firstItem="Ueu-MA-NRe" firstAttribute="trailing" secondItem="YlC-av-iZJ" secondAttribute="trailing" id="8f7-2N-vz4"/>
                                                     <constraint firstAttribute="height" priority="250" constant="358" id="Ank-AM-hXR"/>
                                                     <constraint firstItem="DtX-bu-IVY" firstAttribute="trailing" secondItem="YlC-av-iZJ" secondAttribute="trailing" id="JwI-kE-Gwz"/>
                                                     <constraint firstItem="Sbs-Jr-KdF" firstAttribute="leading" secondItem="YlC-av-iZJ" secondAttribute="leading" id="bbA-ia-NlP"/>
                                                     <constraint firstItem="Ueu-MA-NRe" firstAttribute="leading" secondItem="YlC-av-iZJ" secondAttribute="leading" id="dsZ-cJ-bW5"/>
-                                                    <constraint firstItem="oaT-Cl-Wj8" firstAttribute="leading" secondItem="YlC-av-iZJ" secondAttribute="leading" id="q4K-Gf-sM5"/>
-                                                    <constraint firstItem="oaT-Cl-Wj8" firstAttribute="trailing" secondItem="YlC-av-iZJ" secondAttribute="trailing" id="wzb-Oz-Ut5"/>
+                                                    <constraint firstItem="isn-Vz-XDa" firstAttribute="trailing" secondItem="YlC-av-iZJ" secondAttribute="trailing" id="ibx-hw-ie9"/>
                                                 </constraints>
                                             </stackView>
                                         </subviews>

--- a/Braze Demo/View/Content Cards/ContentCardWebView.swift
+++ b/Braze Demo/View/Content Cards/ContentCardWebView.swift
@@ -15,15 +15,15 @@ class ContentCardWebView: UIView {
     return "\(htmlHead)\(htmlString)"
   }
   
-  func configureView(_ webViewString: String?) {
-    guard let webViewString = webViewString else { return }
-    
-    if let url = URL(string: webViewString) {
-      webView.load(URLRequest(url: url))
-    } else if webViewString.contains("<html") && webViewString.contains("/html>") {
-      self.htmlString = webViewString
-      webView.loadHTMLString(htmlFullString, baseURL: nil)
-    }
+  func configureURLForView(_ urlString: String?) {
+    guard let urlString = urlString, let url = URL(string: urlString) else { return }
+    webView.load(URLRequest(url: url))
+  }
+  
+  func configureHTMLForView(_ htmlString: String?) {
+    guard let htmlString = htmlString else { return }
+    self.htmlString = htmlString
+    webView.loadHTMLString(htmlFullString, baseURL: nil)
   }
 }
 

--- a/Braze Demo/ViewController/AppboySettingsViewController.swift
+++ b/Braze Demo/ViewController/AppboySettingsViewController.swift
@@ -44,7 +44,7 @@ class AppboySettingsViewController: UIViewController {
   }
   @IBAction func messageCenterCampaignButtonPressed(_ sender: Any) {
     guard let button = sender as? UIButton else { return }
-    handleMessageCenterCampaignButtonPressed(with: button.tag)
+    handleMessageCenterCampaignButtonPressed(with: button.titleLabel?.text)
   }
 }
 
@@ -103,18 +103,9 @@ private extension AppboySettingsViewController {
     }
   }
   
-  func handleMessageCenterCampaignButtonPressed(with tag: Int) {
-    var eventTitle = ""
-    switch tag {
-    case 0:
-      eventTitle = "Full Page Pressed"
-    case 1:
-      eventTitle = "HTML Pressed"
-    case 2:
-      eventTitle = "URL Pressed"
-    default:
-      break
-    }
+  func handleMessageCenterCampaignButtonPressed(with title: String?) {
+    guard let title = title else { return }
+    let eventTitle = "\(title) Pressed"
     AppboyManager.shared.logCustomEvent(eventTitle)
     presentAlert(title: eventTitle, message: nil)
   }

--- a/Braze Demo/ViewController/MessageCenterDetailViewController.swift
+++ b/Braze Demo/ViewController/MessageCenterDetailViewController.swift
@@ -68,16 +68,36 @@ private extension MessageCenterDetailViewController {
   }
   
   func loadContentCardWebView(with message: WebViewMessage) {
-    let customHTMLCardView: ContentCardWebView = .fromNib()
+    let contentCardWebView: ContentCardWebView = .fromNib()
     
-    customHTMLCardView.configureView(message.webViewString)
-    view.addSubview(customHTMLCardView)
+    switch message.webViewType {
+    case .contentBlock(let contentBlockId):
+      loadContentBlock(contentBlockId, for: contentCardWebView)
+    case .url(let urlString):
+      contentCardWebView.configureURLForView(urlString)
+    case .html(let htmlString):
+      contentCardWebView.configureHTMLForView(htmlString)
+    default:
+      break
+    }
     
-    customHTMLCardView.translatesAutoresizingMaskIntoConstraints = false
+    layouSubview(contentCardWebView)
+  }
+  
+  func layouSubview(_ subview: UIView) {
+    view.addSubview(subview)
+    subview.translatesAutoresizingMaskIntoConstraints = false
     let attributes: [NSLayoutConstraint.Attribute] = [.top, .bottom, .trailing, .leading]
     NSLayoutConstraint.activate(attributes.map {
-      NSLayoutConstraint(item: customHTMLCardView, attribute: $0, relatedBy: .equal, toItem: view, attribute: $0, multiplier: 1, constant: 0)
+      NSLayoutConstraint(item: subview, attribute: $0, relatedBy: .equal, toItem: view, attribute: $0, multiplier: 1, constant: 0)
     })
+  }
+  
+  func loadContentBlock(_ contentBlockId: String?, for subview: UIView) {
+    guard let contentBlockId = contentBlockId else { return }
+    
+    
+    
   }
 }
 

--- a/Braze Demo/ViewController/MessageCenterDetailViewController.swift
+++ b/Braze Demo/ViewController/MessageCenterDetailViewController.swift
@@ -93,11 +93,23 @@ private extension MessageCenterDetailViewController {
     })
   }
   
-  func loadContentBlock(_ contentBlockId: String?, for subview: UIView) {
+  func loadContentBlock(_ contentBlockId: String?, for contentCardWebView: ContentCardWebView) {
     guard let contentBlockId = contentBlockId else { return }
     
+    let contentBlockAPIKey = "YOUR-CONTENT-BLOCK-API-KEY"
+    let parameters = ["content_block_id": contentBlockId]
+    let request = ContentBlockRequest(contentBlockAPIKey: contentBlockAPIKey, parameters: parameters)
     
-    
+    APIURLRequest().make(request: request) { (result: APIResult<ContentBlock>) in
+      switch result {
+      case .success(let contentBlock):
+        DispatchQueue.main.async {
+          contentCardWebView.configureHTMLForView(contentBlock.content)
+        }
+      case .failure:
+        break
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Added the ability to load a Content Block Id from Braze to load HTML strings that are > 2kb for Content Cards.