### PR TITLE
ABKUIUtils for bottom spacing on SlideFromBottomViewController

### DIFF
--- a/Braze Demo/AppboyManager.swift
+++ b/Braze Demo/AppboyManager.swift
@@ -280,6 +280,9 @@ extension Notification.Name {
   static let reorderHomeScreen = Notification.Name("kReorderHomeScreen")
 }
 
+// MARK: - Slideup In-App Message
+class SlideupViewController: ABKInAppMessageSlideupViewController {}
+
 // MARK: - Modal In-App Message
 class ModalViewController: ABKInAppMessageModalViewController {
   
@@ -301,9 +304,6 @@ class ModalViewController: ABKInAppMessageModalViewController {
     }
   }
 }
-
-// MARK: - Slideup In-App Message
-class SlideupViewController: ABKInAppMessageSlideupViewController {}
 
 // MARK: - Full In-App Message
 class FullViewController: ABKInAppMessageFullViewController {}

--- a/Braze Demo/AppboyManager.swift
+++ b/Braze Demo/AppboyManager.swift
@@ -198,6 +198,13 @@ extension AppboyManager {
   }
 }
 
+// MARK: - Public Methods
+extension AppboyManager {
+  var activeApplicationViewController: UIViewController {
+    return ABKUIUtils.activeApplicationViewController
+  }
+}
+
 // MARK: - Private Methods
 private extension AppboyManager {
   /// Helper method to convert `ABKContentCard` objects to `ContentCardable` objects.
@@ -295,13 +302,16 @@ class ModalViewController: ABKInAppMessageModalViewController {
   }
 }
 
+// MARK: - Slideup In-App Message
+class SlideupViewController: ABKInAppMessageSlideupViewController {}
+
 // MARK: - Full In-App Message
 class FullViewController: ABKInAppMessageFullViewController {}
 
 // MARK: - In-App Message View Controller Helpers
 private extension AppboyManager {
   func slideupViewController(inAppMessage: ABKInAppMessage) -> ABKInAppMessageSlideupViewController {
-    if isInAppMessageSlideFromTop(inAppMessage) {
+    if isInAppMessageSlideFromTop(inAppMessage) || activeApplicationViewController.topMostViewController() is UIAlertController {
       return ABKInAppMessageSlideupViewController(inAppMessage: inAppMessage)
     } else {
       return SlideFromBottomViewController(inAppMessage: inAppMessage)

--- a/Braze Demo/AppboyManager.swift
+++ b/Braze Demo/AppboyManager.swift
@@ -198,7 +198,7 @@ extension AppboyManager {
   }
 }
 
-// MARK: - Public Methods
+// MARK: - ABKUIUtils
 extension AppboyManager {
   var activeApplicationViewController: UIViewController {
     return ABKUIUtils.activeApplicationViewController

--- a/Braze Demo/AppboyManager.swift
+++ b/Braze Demo/AppboyManager.swift
@@ -273,9 +273,6 @@ extension Notification.Name {
   static let reorderHomeScreen = Notification.Name("kReorderHomeScreen")
 }
 
-// MARK: - Slideup In-App Message
-class SlideupViewController: ABKInAppMessageSlideupViewController {}
-
 // MARK: - Modal In-App Message
 class ModalViewController: ABKInAppMessageModalViewController {
   

--- a/Braze Demo/Utils/UIViewController_Util.swift
+++ b/Braze Demo/Utils/UIViewController_Util.swift
@@ -15,12 +15,8 @@ extension UIViewController {
   
   // SOURCE: - https://gist.github.com/db0company/369bfa43cb84b145dfd8#gistcomment-2640891
   func topMostViewController() -> UIViewController {
-    if let presented = self.presentedViewController {
-      if presented is UIAlertController {
-        return self
-      } else {
-        return presented.topMostViewController()
-      }
+    if let presented = presentedViewController {
+      return presented.topMostViewController()
     }
           
     if let navigation = self as? UINavigationController {

--- a/Braze Demo/Utils/UIViewController_Util.swift
+++ b/Braze Demo/Utils/UIViewController_Util.swift
@@ -12,4 +12,21 @@ extension UIViewController {
     }
     present(alert, animated: true, completion: nil)
   }
+  
+  // SOURCE: - https://gist.github.com/db0company/369bfa43cb84b145dfd8#gistcomment-2640891
+  func topMostViewController() -> UIViewController {
+    if let presented = self.presentedViewController {
+      return presented.topMostViewController()
+    }
+          
+    if let navigation = self as? UINavigationController {
+      return navigation.visibleViewController?.topMostViewController() ?? navigation
+    }
+          
+    if let tab = self as? UITabBarController {
+      return tab.selectedViewController?.topMostViewController() ?? tab
+    }
+          
+    return self
+  }
 }

--- a/Braze Demo/Utils/UIViewController_Util.swift
+++ b/Braze Demo/Utils/UIViewController_Util.swift
@@ -16,7 +16,11 @@ extension UIViewController {
   // SOURCE: - https://gist.github.com/db0company/369bfa43cb84b145dfd8#gistcomment-2640891
   func topMostViewController() -> UIViewController {
     if let presented = self.presentedViewController {
-      return presented.topMostViewController()
+      if presented is UIAlertController {
+        return self
+      } else {
+        return presented.topMostViewController()
+      }
     }
           
     if let navigation = self as? UINavigationController {

--- a/Braze Demo/Utils/UIViewController_Util.swift
+++ b/Braze Demo/Utils/UIViewController_Util.swift
@@ -26,7 +26,7 @@ extension UIViewController {
     if let tab = self as? UITabBarController {
       return tab.selectedViewController?.topMostViewController() ?? tab
     }
-          
+        
     return self
   }
 }

--- a/Braze Demo/View/SlideFromBottomViewController.swift
+++ b/Braze Demo/View/SlideFromBottomViewController.swift
@@ -1,11 +1,10 @@
 import UIKit
-import Appboy_iOS_SDK
 
-class SlideFromBottomViewController: ABKInAppMessageSlideupViewController {
+class SlideFromBottomViewController: SlideupViewController {
 
   // MARK: - Variables
   private var bottomSpacing: CGFloat {
-    return ABKUIUtils.activeApplicationViewController.topMostViewController().view.safeAreaInsets.bottom
+    return AppboyManager.shared.activeApplicationViewController.topMostViewController().view.safeAreaInsets.bottom
   }
 }
 

--- a/Braze Demo/View/SlideFromBottomViewController.swift
+++ b/Braze Demo/View/SlideFromBottomViewController.swift
@@ -1,9 +1,12 @@
 import UIKit
+import Appboy_iOS_SDK
 
-class SlideFromBottomViewController: SlideupViewController {
+class SlideFromBottomViewController: ABKInAppMessageSlideupViewController {
 
   // MARK: - Variables
-  private let tabBarHeight: CGFloat = 50
+  private var bottomSpacing: CGFloat {
+    return ABKUIUtils.activeApplicationViewController.topMostViewController().view.safeAreaInsets.bottom
+  }
 }
 
 // MARK: - View Lifecycle
@@ -25,8 +28,6 @@ extension SlideFromBottomViewController {
 // MARK: - Private
 private extension SlideFromBottomViewController {
   func setSlideConstraint() {
-    guard let superview = view.superview else { return }
-    
-    slideConstraint?.constant = superview.safeAreaInsets.bottom + tabBarHeight
+    slideConstraint?.constant = bottomSpacing
   }
 }


### PR DESCRIPTION
Got rid of hardcoded value of `tabBarHeight` due to the dynamic nature of view controller appearances. Not all view controllers will have a tab bar present (i.e. modally presented view controllers). This would throw off the look and feel to hardcode the value in the case of the opposite expectation. 

Currently using ABKUIUtils to get the root view controller and using that to get the `topMostViewController()` to query the safeAreaInsets.bottom

If the `topMostViewController()` is a `UIAlertController`,  let the superclass handle it and fall back to the `ABKSlideupViewController`

<img src="https://user-images.githubusercontent.com/5905170/102426062-3a613d80-3fd4-11eb-95e4-3edf56c8515f.png" width="414" height="896">

<img src="https://user-images.githubusercontent.com/5905170/102426066-3c2b0100-3fd4-11eb-8635-418860d2adcc.png" width="414" height="896">

<img src="https://user-images.githubusercontent.com/5905170/102436122-819ffc00-3fdd-11eb-8c30-471eee453eb1.png" width="414" height="896">
