### PR TITLE
Generic setCustomAttribute Helper Method

### DIFF
--- a/Braze Demo/AppboyManager.swift
+++ b/Braze Demo/AppboyManager.swift
@@ -104,14 +104,25 @@ extension AppboyManager {
     Appboy.sharedInstance()?.logCustomEvent(eventName, withProperties: properties)
   }
   
-  func setCustomAttributeWithKey(_ key: String?, andStringValue value: String?) {
+  func setCustomAttributeWithKey<T: Equatable>(_ key: String?, andValue value: T?) {
     guard let key = key, let value = value else { return }
-    Appboy.sharedInstance()?.user.setCustomAttributeWithKey(key, andStringValue: value)
-  }
-  
-  func setCustomAttributeWithKey(_ key: String?, andArrayValue value: [Any]?) {
-    guard let key = key, let value = value else { return }
-    Appboy.sharedInstance()?.user.setCustomAttributeArrayWithKey(key, array: value)
+    
+    switch value.self {
+    case let value as Array<String>:
+      Appboy.sharedInstance()?.user.setCustomAttributeArrayWithKey(key, array: value)
+    case let value as Date:
+      Appboy.sharedInstance()?.user.setCustomAttributeWithKey(key, andDateValue: value)
+    case let value as Bool:
+      Appboy.sharedInstance()?.user.setCustomAttributeWithKey(key, andBOOLValue: value)
+    case let value as String:
+      Appboy.sharedInstance()?.user.setCustomAttributeWithKey(key, andStringValue: value)
+    case let value as Double:
+      Appboy.sharedInstance()?.user.setCustomAttributeWithKey(key, andDoubleValue: value)
+    case let value as Int:
+      Appboy.sharedInstance()?.user.setCustomAttributeWithKey(key, andIntegerValue: value)
+    default:
+      return
+    }
   }
   
   func logPurchase(productIdentifier: String, inCurrency currency: String, atPrice price: String, withQuanitity quanity: Int) {

--- a/Braze Demo/ViewController/In App Messages/FullListViewController/FullListViewController.swift
+++ b/Braze Demo/ViewController/In App Messages/FullListViewController/FullListViewController.swift
@@ -14,7 +14,7 @@ class FullListViewController: FullViewController {
   @IBAction func primaryButtonTapped(_ sender: Any) {
     guard let attributeKey = inAppMessage.extras?["attribute_key"] as? String else { return }
     
-    AppboyManager.shared.setCustomAttributeWithKey(attributeKey, andArrayValue: selectedItems)
+    AppboyManager.shared.setCustomAttributeWithKey(attributeKey, andValue: selectedItems)
   }
   
   // MARK: - Variables

--- a/Braze Demo/ViewController/In App Messages/ModalPickerViewController/ModalPickerViewController.swift
+++ b/Braze Demo/ViewController/In App Messages/ModalPickerViewController/ModalPickerViewController.swift
@@ -9,7 +9,7 @@ class ModalPickerViewController: ModalViewController {
   @IBAction func primaryButtonTapped(_ sender: Any) {
     guard let item = selectedItem, !item.isEmpty, let attributeKey = inAppMessage.extras?[InAppMessageKey.attributeKey.rawValue] as? String else { return }
     
-    AppboyManager.shared.setCustomAttributeWithKey(attributeKey, andStringValue: item)
+    AppboyManager.shared.setCustomAttributeWithKey(attributeKey, andValue: item)
   }
   
   // MARK: - Variables


### PR DESCRIPTION
Users shouldn't have to make x amount of helper methods to account for the different type values. Let the user call one method from the `AppboyManager` and let method filter down the specific custom attribute it needs to set based on the value's type. 

Went with `<T: Equatable>` to make it a little more targeted than just `<T>`