### PR TITLE
Refactored RemoteStorage to class

### DIFF
--- a/Braze-Demo/Cache/RemoteStorage.swift
+++ b/Braze-Demo/Cache/RemoteStorage.swift
@@ -20,8 +20,17 @@ enum RemoteStorageType {
   case suite
 }
 
-struct RemoteStorage {
+class RemoteStorage: NSObject {
+  // MARK: - Variables
   private var storageType: RemoteStorageType = .standard
+  private lazy var defaults: UserDefaults = {
+    switch storageType {
+    case .standard:
+      return .standard
+    case .suite:
+      return UserDefaults(suiteName: "group.com.braze.book-demo")!
+    }
+  }()
   
   init(storageType: RemoteStorageType = .standard) {
     self.storageType = storageType
@@ -42,18 +51,6 @@ struct RemoteStorage {
   func resetStorageKeys() {
     for key in RemoteStorageKey.allCases {
       defaults.removeObject(forKey: key.rawValue)
-    }
-  }
-}
-
-// MARK: Private
-private extension RemoteStorage {
-  var defaults: UserDefaults {
-    switch storageType {
-    case .standard:
-      return .standard
-    case .suite:
-      return UserDefaults(suiteName: "group.com.braze.book-demo")!
     }
   }
 }


### PR DESCRIPTION
Refactored `defaults` to be a `lazy` variable instead of a computed variable because every time `defaults` was called a new instance of `UserDefaults` was initialized. 

Now once `defaults` is initialized, the `UserDefaults` instance will remain the same once it is initialized for the lifetime of that `RemoteStorage` instance. 