### PR TITLE
Custom Full IAM for iOS 14.5 app tracking transparency

### DIFF
--- a/Braze-Demo.xcodeproj/project.pbxproj
+++ b/Braze-Demo.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		7F87D4AA24B0500200ED0A86 /* BrazeSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F87D4A924B0500200ED0A86 /* BrazeSettingsViewController.swift */; };
 		7F87D4AC24B2709400ED0A86 /* ShoppingCartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F87D4AB24B2709400ED0A86 /* ShoppingCartViewController.swift */; };
 		7F87D4AE24B2A24B00ED0A86 /* TextField_Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F87D4AD24B2A24B00ED0A86 /* TextField_Util.swift */; };
+		7F88F9992644969500B68025 /* FullPermissionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F88F9982644969500B68025 /* FullPermissionViewController.swift */; };
+		7F88F9A3264496A000B68025 /* FullPermissionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7F88F9A2264496A000B68025 /* FullPermissionViewController.xib */; };
 		7F8967C625740F9900C61405 /* FullListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8967C525740F9900C61405 /* FullListViewController.swift */; };
 		7F8967CB25740FA600C61405 /* FullListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7F8967CA25740FA600C61405 /* FullListViewController.xib */; };
 		7F8967D42574246B00C61405 /* SwitchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8967D32574246B00C61405 /* SwitchTableViewCell.swift */; };
@@ -300,6 +302,8 @@
 		7F87D4A924B0500200ED0A86 /* BrazeSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrazeSettingsViewController.swift; sourceTree = "<group>"; };
 		7F87D4AB24B2709400ED0A86 /* ShoppingCartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingCartViewController.swift; sourceTree = "<group>"; };
 		7F87D4AD24B2A24B00ED0A86 /* TextField_Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextField_Util.swift; sourceTree = "<group>"; };
+		7F88F9982644969500B68025 /* FullPermissionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullPermissionViewController.swift; sourceTree = "<group>"; };
+		7F88F9A2264496A000B68025 /* FullPermissionViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FullPermissionViewController.xib; sourceTree = "<group>"; };
 		7F8967C525740F9900C61405 /* FullListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullListViewController.swift; sourceTree = "<group>"; };
 		7F8967CA25740FA600C61405 /* FullListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FullListViewController.xib; sourceTree = "<group>"; };
 		7F8967D32574246B00C61405 /* SwitchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchTableViewCell.swift; sourceTree = "<group>"; };
@@ -650,6 +654,15 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
+		7F88F9AC264496A500B68025 /* FullPermissionViewController */ = {
+			isa = PBXGroup;
+			children = (
+				7F88F9982644969500B68025 /* FullPermissionViewController.swift */,
+				7F88F9A2264496A000B68025 /* FullPermissionViewController.xib */,
+			);
+			path = FullPermissionViewController;
+			sourceTree = "<group>";
+		};
 		7F8967CF25740FAB00C61405 /* FullListViewController */ = {
 			isa = PBXGroup;
 			children = (
@@ -894,6 +907,7 @@
 			isa = PBXGroup;
 			children = (
 				7F8967CF25740FAB00C61405 /* FullListViewController */,
+				7F88F9AC264496A500B68025 /* FullPermissionViewController */,
 				7F3FBEF325B0F417007715C0 /* ModalPickerViewController */,
 				7F6C94C1255F8866000CDAAA /* SlideFromBottomViewController.swift */,
 			);
@@ -1229,6 +1243,7 @@
 				7FD8EA3225E75942004A89FA /* Sailec-HairlineItalic.otf in Resources */,
 				7FCFEB19256C38B500079EAF /* ModalPickerViewController.xib in Resources */,
 				7FD2F5FB2564C6C00061950D /* HomeScreenMenuView.xib in Resources */,
+				7F88F9A3264496A000B68025 /* FullPermissionViewController.xib in Resources */,
 				7F754FC1250C2DF000CD7B45 /* Tile-List.json in Resources */,
 				7FD8EA2E25E75942004A89FA /* Sailec-BoldItalic.otf in Resources */,
 				7FC3106824D1C30100053D90 /* ContentCardGestureView.xib in Resources */,
@@ -1377,6 +1392,7 @@
 				7FC3106624D1C29A00053D90 /* ContentCardGestureView.swift in Sources */,
 				7F384B4E256DC59300673410 /* InAppMessageData.swift in Sources */,
 				7FD2F6002564C6CA0061950D /* HomeScreenMenuView.swift in Sources */,
+				7F88F9992644969500B68025 /* FullPermissionViewController.swift in Sources */,
 				7F554A312585F2B400DAFB84 /* SmallRowCollectionViewCell.swift in Sources */,
 				7F87D4AC24B2709400ED0A86 /* ShoppingCartViewController.swift in Sources */,
 				7F554A3725871FE900DAFB84 /* HeaderSupplementaryView.swift in Sources */,

--- a/Braze-Demo/BrazeManager.swift
+++ b/Braze-Demo/BrazeManager.swift
@@ -359,6 +359,8 @@ private extension BrazeManager {
     switch inAppMessage.extras?[InAppMessageKey.viewType.rawValue] as? String {
     case InAppMessageViewType.tableList.rawValue:
       return FullListViewController(inAppMessage: inAppMessage)
+    case InAppMessageViewType.permission.rawValue:
+      return FullPermissionViewController(inAppMessage: inAppMessage)
     default:
       return ABKInAppMessageFullViewController(inAppMessage: inAppMessage)
     }

--- a/Braze-Demo/Info.plist
+++ b/Braze-Demo/Info.plist
@@ -75,6 +75,8 @@
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>This allows us to provide you a better ads experience.</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Braze-Demo/Model/In-App-Messages/InAppMessageData.swift
+++ b/Braze-Demo/Model/In-App-Messages/InAppMessageData.swift
@@ -12,4 +12,5 @@ enum InAppMessageKey: String {
 enum InAppMessageViewType: String {
   case picker
   case tableList = "table_list"
+  case permission
 }

--- a/Braze-Demo/Storyboard/Main.storyboard
+++ b/Braze-Demo/Storyboard/Main.storyboard
@@ -77,18 +77,18 @@
                                 </connections>
                             </button>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Oa7-Ni-fSI">
-                                <rect key="frame" x="0.0" y="44" width="600" height="398"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="650"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MessageCenterTableViewCell" id="pU3-1V-zAV" customClass="MessageCenterTableViewCell" customModule="Braze_Demo" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="600" height="50.5"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="50.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pU3-1V-zAV" id="tx8-MK-0vF">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="50.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="50.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RFW-3W-yBW" userLabel="Title Container">
-                                                    <rect key="frame" x="20" y="10" width="373.5" height="30.5"/>
+                                                    <rect key="frame" x="20" y="10" width="249.5" height="30.5"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="1yZ-aM-1Ti" userLabel="Title Image">
                                                             <rect key="frame" x="0.0" y="0.5" width="30" height="30"/>
@@ -98,7 +98,7 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem Ipsum" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vrC-30-Zj2">
-                                                            <rect key="frame" x="40" y="0.0" width="333.5" height="30.5"/>
+                                                            <rect key="frame" x="40" y="0.0" width="209.5" height="30.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -117,10 +117,10 @@
                                                     </constraints>
                                                 </view>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QcO-S2-Jk2" userLabel="Date Container">
-                                                    <rect key="frame" x="393.5" y="0.0" width="186.5" height="50.5"/>
+                                                    <rect key="frame" x="269.5" y="0.0" width="124.5" height="50.5"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DgZ-pk-h6p">
-                                                            <rect key="frame" x="0.0" y="0.0" width="186.5" height="50.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="124.5" height="50.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -1070,10 +1070,10 @@
                                 <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f62-ya-u1v" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="491.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="566.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ADU-aS-6iU">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="491.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="566.5"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fVq-bb-FJA" userLabel="Campaign">
                                                         <rect key="frame" x="0.0" y="0.0" width="414" height="150.5"/>
@@ -1164,7 +1164,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tZE-CT-Cdg" userLabel="Campaign">
-                                                        <rect key="frame" x="0.0" y="341" width="414" height="150.5"/>
+                                                        <rect key="frame" x="0.0" y="341" width="414" height="225.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Full-Screen" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tj7-qG-hah">
                                                                 <rect key="frame" x="161" y="20" width="92" height="20.5"/>
@@ -1196,15 +1196,42 @@
                                                                     <action selector="triggerPressed:" destination="FpX-RM-6ac" eventType="touchUpInside" id="GUu-hk-qZB"/>
                                                                 </connections>
                                                             </button>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rhw-x6-h5A">
+                                                                <rect key="frame" x="20" y="125.5" width="374" height="50"/>
+                                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="50" id="BSe-gS-07h"/>
+                                                                </constraints>
+                                                                <state key="normal" title="App Tracking Transparency">
+                                                                    <color key="titleColor" systemColor="systemBackgroundColor"/>
+                                                                </state>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                        <integer key="value" value="5"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
+                                                                        <real key="value" value="0.5"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                    <userDefinedRuntimeAttribute type="size" keyPath="layer.shadowOffset">
+                                                                        <size key="value" width="0.0" height="2"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                </userDefinedRuntimeAttributes>
+                                                                <connections>
+                                                                    <action selector="triggerPressed:" destination="FpX-RM-6ac" eventType="touchUpInside" id="KKS-o6-lWc"/>
+                                                                </connections>
+                                                            </button>
                                                         </subviews>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <constraints>
                                                             <constraint firstItem="tj7-qG-hah" firstAttribute="centerX" secondItem="tZE-CT-Cdg" secondAttribute="centerX" id="3MJ-fy-hE7"/>
                                                             <constraint firstItem="tj7-qG-hah" firstAttribute="top" secondItem="tZE-CT-Cdg" secondAttribute="top" constant="20" id="9Ke-6a-5CX"/>
+                                                            <constraint firstItem="Rhw-x6-h5A" firstAttribute="top" secondItem="x5c-xb-WRL" secondAttribute="bottom" constant="25" id="9lD-jJ-utR"/>
                                                             <constraint firstItem="x5c-xb-WRL" firstAttribute="top" secondItem="tj7-qG-hah" secondAttribute="bottom" constant="10" id="IYa-9M-B3T"/>
+                                                            <constraint firstItem="Rhw-x6-h5A" firstAttribute="trailing" secondItem="x5c-xb-WRL" secondAttribute="trailing" id="XmJ-CM-WVV"/>
+                                                            <constraint firstItem="Rhw-x6-h5A" firstAttribute="leading" secondItem="x5c-xb-WRL" secondAttribute="leading" id="dr0-2h-0jE"/>
                                                             <constraint firstItem="x5c-xb-WRL" firstAttribute="leading" secondItem="tZE-CT-Cdg" secondAttribute="leading" constant="20" id="gt3-Cl-ivb"/>
-                                                            <constraint firstAttribute="bottom" secondItem="x5c-xb-WRL" secondAttribute="bottom" constant="50" id="nBf-hK-Cdu"/>
                                                             <constraint firstAttribute="trailing" secondItem="x5c-xb-WRL" secondAttribute="trailing" constant="20" id="pK4-9X-PPG"/>
+                                                            <constraint firstAttribute="bottom" secondItem="Rhw-x6-h5A" secondAttribute="bottom" constant="50" id="sXG-NV-b7W"/>
                                                         </constraints>
                                                     </view>
                                                 </subviews>

--- a/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.swift
+++ b/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+class FullPermissionViewController: FullViewController {
+  
+  override var nibName: String {
+    return "FullPermissionViewController"
+  }
+}
+
+// MARK: - View Lifecycle
+extension FullPermissionViewController {
+  override func loadView() {
+    Bundle.main.loadNibNamed(nibName, owner: self, options: nil)
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    
+    inAppMessageHeaderLabel?.textAlignment = .center
+  }
+}

--- a/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.swift
+++ b/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.swift
@@ -2,6 +2,12 @@ import UIKit
 
 class FullPermissionViewController: FullViewController {
   
+  // MARK: - Outlets
+  @IBOutlet private weak var permissionView: UIView!
+  @IBOutlet private weak var arrowView: UIView!
+  @IBOutlet private weak var permissionTitle: UILabel!
+  @IBOutlet private weak var permissionSubtitle: UILabel!
+  
   override var nibName: String {
     return "FullPermissionViewController"
   }
@@ -11,6 +17,18 @@ class FullPermissionViewController: FullViewController {
 extension FullPermissionViewController {
   override func loadView() {
     Bundle.main.loadNibNamed(nibName, owner: self, options: nil)
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    if let titleText = inAppMessage.extras?["permission_title"] as? String {
+      permissionTitle.text = titleText
+    }
+    
+    if let subtitleText = inAppMessage.extras?["permission_subtitle"] as? String {
+      permissionSubtitle.text = subtitleText
+    }
   }
   
   override func viewWillAppear(_ animated: Bool) {

--- a/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.swift
+++ b/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.swift
@@ -1,13 +1,31 @@
 import UIKit
+import AppTrackingTransparency
 
 class FullPermissionViewController: FullViewController {
   
   // MARK: - Outlets
   @IBOutlet private weak var permissionView: UIView!
-  @IBOutlet private weak var arrowView: UIView!
+  @IBOutlet private weak var checkboxButton: UIButton!
   @IBOutlet private weak var permissionTitle: UILabel!
   @IBOutlet private weak var permissionSubtitle: UILabel!
   
+  // MARK: Actions
+  @IBAction func checkboxDidTap(_ sender: Any) {
+    ATTrackingManager.requestTrackingAuthorization { [weak self] status in
+      guard let self = self else { return }
+      
+      switch status {
+      case .authorized:
+        DispatchQueue.main.async {
+          self.checkboxButton.setTitle("✓", for: .normal)
+        }
+      default:
+        break
+      }
+    }
+  }
+  
+  // MARK: - Variables
   override var nibName: String {
     return "FullPermissionViewController"
   }

--- a/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.swift
+++ b/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.swift
@@ -51,7 +51,23 @@ extension FullPermissionViewController {
   
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+    configureGradient()
     
     inAppMessageHeaderLabel?.textAlignment = .center
+  }
+}
+
+// MARK:- Private
+private extension FullPermissionViewController {
+  func configureGradient() {
+    let colorTop =  UIColor(red: 255.0/255.0, green: 255.0/255.0, blue: 255.0/255.0, alpha: 1.0).cgColor
+    let colorBottom = UIColor(red: 200.0/255.0, green: 200.0/255.0, blue: 200.0/255.0, alpha: 1.0).cgColor
+                    
+    let gradientLayer = CAGradientLayer()
+    gradientLayer.colors = [colorTop, colorBottom]
+    gradientLayer.locations = [0.25, 1.0]
+    gradientLayer.frame = view.bounds
+                
+    view.layer.insertSublayer(gradientLayer, at:0)
   }
 }

--- a/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.xib
+++ b/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.xib
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="Sailec-Black.otf">
+            <string>Sailec-Black</string>
+        </array>
+    </customFonts>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FullPermissionViewController" customModule="Braze_Demo" customModuleProvider="target">
+            <connections>
+                <outlet property="iconImageView" destination="NMj-Ey-DBa" id="mxF-nk-nrN"/>
+                <outlet property="inAppMessageHeaderLabel" destination="hcG-dV-pwK" id="Xb6-QZ-kI6"/>
+                <outlet property="inAppMessageMessageLabel" destination="cl7-AA-xVz" id="IJu-8j-PZ5"/>
+                <outlet property="rightInAppMessageButton" destination="Nee-Hy-VgV" id="KCv-Xz-SM6"/>
+                <outlet property="view" destination="m8E-5B-yok" id="OqD-9E-ckD"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="m8E-5B-yok" customClass="ABKInAppMessageView">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="NMj-Ey-DBa">
+                    <rect key="frame" x="138" y="44" width="138" height="138"/>
+                    <constraints>
+                        <constraint firstAttribute="width" secondItem="NMj-Ey-DBa" secondAttribute="height" multiplier="1:1" id="obR-kW-qIw"/>
+                    </constraints>
+                </imageView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cl7-AA-xVz">
+                    <rect key="frame" x="10" y="297" width="394" height="22"/>
+                    <attributedString key="attributedText">
+                        <fragment content="LOREM IPSUM:">
+                            <attributes>
+                                <font key="NSFont" size="22" name="Sailec-Regular"/>
+                                <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="4" tighteningFactorForTruncation="0.0"/>
+                            </attributes>
+                        </fragment>
+                    </attributedString>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LOREM IPSUM" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hcG-dV-pwK">
+                    <rect key="frame" x="10" y="222" width="394" height="50"/>
+                    <fontDescription key="fontDescription" name="Sailec-Black" family="Sailec" pointSize="50"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8KP-p7-85P">
+                    <rect key="frame" x="10" y="365" width="75" height="75"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="75" id="8t3-P0-Pve"/>
+                        <constraint firstAttribute="height" constant="75" id="FSq-Ei-hhD"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
+                            <integer key="value" value="2"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="10"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </view>
+                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nee-Hy-VgV" customClass="ABKInAppMessageUIButton">
+                    <rect key="frame" x="313" y="674" width="46" height="30"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="Button"/>
+                </button>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="9wH-qX-TCC"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="hcG-dV-pwK" firstAttribute="top" secondItem="NMj-Ey-DBa" secondAttribute="bottom" constant="40" id="2DI-sv-EOl"/>
+                <constraint firstItem="NMj-Ey-DBa" firstAttribute="top" secondItem="9wH-qX-TCC" secondAttribute="top" id="8u0-YO-74H"/>
+                <constraint firstItem="8KP-p7-85P" firstAttribute="top" secondItem="cl7-AA-xVz" secondAttribute="bottom" constant="46" id="IJ2-sH-pHI"/>
+                <constraint firstItem="hcG-dV-pwK" firstAttribute="leading" secondItem="9wH-qX-TCC" secondAttribute="leading" constant="10" id="XHL-Dl-EbW"/>
+                <constraint firstItem="NMj-Ey-DBa" firstAttribute="width" secondItem="m8E-5B-yok" secondAttribute="width" multiplier="1:3" id="Z2h-KD-PBb"/>
+                <constraint firstItem="cl7-AA-xVz" firstAttribute="leading" secondItem="hcG-dV-pwK" secondAttribute="leading" id="b04-jf-h7f"/>
+                <constraint firstItem="9wH-qX-TCC" firstAttribute="trailing" secondItem="hcG-dV-pwK" secondAttribute="trailing" constant="10" id="ctS-GS-fX8"/>
+                <constraint firstItem="8KP-p7-85P" firstAttribute="leading" secondItem="9wH-qX-TCC" secondAttribute="leading" constant="10" id="dDz-ap-fVW"/>
+                <constraint firstItem="cl7-AA-xVz" firstAttribute="top" secondItem="hcG-dV-pwK" secondAttribute="bottom" constant="25" id="qdd-BH-hgz"/>
+                <constraint firstItem="cl7-AA-xVz" firstAttribute="trailing" secondItem="hcG-dV-pwK" secondAttribute="trailing" id="rpv-oj-dVM"/>
+                <constraint firstItem="NMj-Ey-DBa" firstAttribute="centerX" secondItem="9wH-qX-TCC" secondAttribute="centerX" id="ver-0I-zyL"/>
+            </constraints>
+            <point key="canvasLocation" x="-507" y="39"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.xib
+++ b/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.xib
@@ -128,13 +128,13 @@
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem Ipsum" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CoG-z9-Rn6">
                                     <rect key="frame" x="0.0" y="0.0" width="289" height="31.5"/>
-                                    <fontDescription key="fontDescription" name="Sailec-Medium" family="Sailec" pointSize="17"/>
+                                    <fontDescription key="fontDescription" name="Sailec-Medium" family="Sailec" pointSize="15"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem Ipsum" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u2E-My-PMl">
                                     <rect key="frame" x="0.0" y="43.5" width="289" height="31.5"/>
-                                    <fontDescription key="fontDescription" name="Sailec-Regular" family="Sailec" pointSize="17"/>
+                                    <fontDescription key="fontDescription" name="Sailec-Regular" family="Sailec" pointSize="15"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>

--- a/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.xib
+++ b/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.xib
@@ -21,6 +21,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FullPermissionViewController" customModule="Braze_Demo" customModuleProvider="target">
             <connections>
+                <outlet property="checkboxButton" destination="df7-8W-uwH" id="tOr-1X-FfV"/>
                 <outlet property="iconImageView" destination="NMj-Ey-DBa" id="mxF-nk-nrN"/>
                 <outlet property="inAppMessageHeaderLabel" destination="hcG-dV-pwK" id="Xb6-QZ-kI6"/>
                 <outlet property="inAppMessageMessageLabel" destination="cl7-AA-xVz" id="IJu-8j-PZ5"/>
@@ -95,6 +96,13 @@
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="df7-8W-uwH">
                                     <rect key="frame" x="0.0" y="0.0" width="75" height="75"/>
+                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="60"/>
+                                    <state key="normal">
+                                        <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="checkboxDidTap:" destination="-1" eventType="touchUpInside" id="wd5-VA-min"/>
+                                    </connections>
                                 </button>
                             </subviews>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.xib
+++ b/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.xib
@@ -11,6 +11,12 @@
         <array key="Sailec-Black.otf">
             <string>Sailec-Black</string>
         </array>
+        <array key="Sailec-Medium.otf">
+            <string>Sailec-Medium</string>
+        </array>
+        <array key="Sailec-Regular.otf">
+            <string>Sailec-Regular</string>
+        </array>
     </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FullPermissionViewController" customModule="Braze_Demo" customModuleProvider="target">
@@ -18,6 +24,9 @@
                 <outlet property="iconImageView" destination="NMj-Ey-DBa" id="mxF-nk-nrN"/>
                 <outlet property="inAppMessageHeaderLabel" destination="hcG-dV-pwK" id="Xb6-QZ-kI6"/>
                 <outlet property="inAppMessageMessageLabel" destination="cl7-AA-xVz" id="IJu-8j-PZ5"/>
+                <outlet property="permissionSubtitle" destination="u2E-My-PMl" id="tJa-8M-mIL"/>
+                <outlet property="permissionTitle" destination="CoG-z9-Rn6" id="ngv-ys-vcN"/>
+                <outlet property="permissionView" destination="5SO-af-bAa" id="GFd-Ln-6BM"/>
                 <outlet property="rightInAppMessageButton" destination="Nee-Hy-VgV" id="KCv-Xz-SM6"/>
                 <outlet property="view" destination="m8E-5B-yok" id="OqD-9E-ckD"/>
             </connections>
@@ -27,6 +36,24 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
+                <button opaque="NO" tag="50" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cB6-s8-UVB">
+                    <rect key="frame" x="349" y="44" width="40" height="40"/>
+                    <accessibility key="accessibilityConfiguration" label="Close In App Message"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="40" id="AJt-1x-UiS"/>
+                        <constraint firstAttribute="width" constant="40" id="j9W-mU-mAZ"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                    <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <inset key="imageEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
+                    <state key="normal" title="Skip">
+                        <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
+                    <connections>
+                        <action selector="dismissInAppMessage:" destination="-1" eventType="touchUpInside" id="ivL-u7-tCM"/>
+                    </connections>
+                </button>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="NMj-Ey-DBa">
                     <rect key="frame" x="138" y="44" width="138" height="138"/>
                     <constraints>
@@ -34,11 +61,11 @@
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cl7-AA-xVz">
-                    <rect key="frame" x="10" y="297" width="394" height="22"/>
+                    <rect key="frame" x="10" y="287" width="394" height="20"/>
                     <attributedString key="attributedText">
                         <fragment content="LOREM IPSUM:">
                             <attributes>
-                                <font key="NSFont" size="22" name="Sailec-Regular"/>
+                                <font key="NSFont" size="20" name="Sailec-Regular"/>
                                 <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="4" tighteningFactorForTruncation="0.0"/>
                             </attributes>
                         </fragment>
@@ -46,45 +73,98 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LOREM IPSUM" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hcG-dV-pwK">
-                    <rect key="frame" x="10" y="222" width="394" height="50"/>
-                    <fontDescription key="fontDescription" name="Sailec-Black" family="Sailec" pointSize="50"/>
+                    <rect key="frame" x="10" y="222" width="394" height="40"/>
+                    <fontDescription key="fontDescription" name="Sailec-Black" family="Sailec" pointSize="40"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8KP-p7-85P">
-                    <rect key="frame" x="10" y="365" width="75" height="75"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nee-Hy-VgV" customClass="ABKInAppMessageUIButton">
+                    <rect key="frame" x="25" y="532" width="364" height="50"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="75" id="8t3-P0-Pve"/>
-                        <constraint firstAttribute="height" constant="75" id="FSq-Ei-hhD"/>
+                        <constraint firstAttribute="height" constant="50" id="qCA-A2-m2i"/>
                     </constraints>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
-                            <integer key="value" value="2"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                            <integer key="value" value="10"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
-                </view>
-                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nee-Hy-VgV" customClass="ABKInAppMessageUIButton">
-                    <rect key="frame" x="313" y="674" width="46" height="30"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <state key="normal" title="Button"/>
+                    <connections>
+                        <action selector="buttonClicked:" destination="-1" eventType="touchUpInside" id="j71-DV-omy"/>
+                    </connections>
                 </button>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5SO-af-bAa" userLabel="Permssion VIew">
+                    <rect key="frame" x="10" y="357" width="394" height="75"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8KP-p7-85P" userLabel="Checkbox View">
+                            <rect key="frame" x="0.0" y="0.0" width="75" height="75"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="df7-8W-uwH">
+                                    <rect key="frame" x="0.0" y="0.0" width="75" height="75"/>
+                                </button>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="75" id="8t3-P0-Pve"/>
+                                <constraint firstItem="df7-8W-uwH" firstAttribute="leading" secondItem="8KP-p7-85P" secondAttribute="leading" id="B8W-rb-Txa"/>
+                                <constraint firstAttribute="height" constant="75" id="FSq-Ei-hhD"/>
+                                <constraint firstItem="df7-8W-uwH" firstAttribute="top" secondItem="8KP-p7-85P" secondAttribute="top" id="enl-LG-VhL"/>
+                                <constraint firstAttribute="bottom" secondItem="df7-8W-uwH" secondAttribute="bottom" id="ph6-VF-sOH"/>
+                                <constraint firstAttribute="trailing" secondItem="df7-8W-uwH" secondAttribute="trailing" id="wjV-Z9-xvL"/>
+                            </constraints>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
+                                    <integer key="value" value="2"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                    <integer key="value" value="10"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                        </view>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="JYn-xY-2OT">
+                            <rect key="frame" x="105" y="0.0" width="289" height="75"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem Ipsum" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CoG-z9-Rn6">
+                                    <rect key="frame" x="0.0" y="0.0" width="289" height="31.5"/>
+                                    <fontDescription key="fontDescription" name="Sailec-Medium" family="Sailec" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem Ipsum" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u2E-My-PMl">
+                                    <rect key="frame" x="0.0" y="43.5" width="289" height="31.5"/>
+                                    <fontDescription key="fontDescription" name="Sailec-Regular" family="Sailec" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="JYn-xY-2OT" firstAttribute="centerY" secondItem="8KP-p7-85P" secondAttribute="centerY" id="0YA-Hh-NDi"/>
+                        <constraint firstAttribute="bottom" secondItem="JYn-xY-2OT" secondAttribute="bottom" id="1Nz-ic-RHb"/>
+                        <constraint firstItem="JYn-xY-2OT" firstAttribute="top" secondItem="5SO-af-bAa" secondAttribute="top" id="9g5-tz-IGg"/>
+                        <constraint firstItem="8KP-p7-85P" firstAttribute="top" relation="greaterThanOrEqual" secondItem="5SO-af-bAa" secondAttribute="top" id="Al1-0e-9F8"/>
+                        <constraint firstItem="8KP-p7-85P" firstAttribute="leading" secondItem="5SO-af-bAa" secondAttribute="leading" id="E17-fj-mTz"/>
+                        <constraint firstItem="JYn-xY-2OT" firstAttribute="leading" secondItem="8KP-p7-85P" secondAttribute="trailing" constant="30" id="JJA-10-bam"/>
+                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="8KP-p7-85P" secondAttribute="bottom" id="ego-E8-rSk"/>
+                        <constraint firstAttribute="trailing" secondItem="JYn-xY-2OT" secondAttribute="trailing" id="g3y-lH-Tsb"/>
+                    </constraints>
+                </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="9wH-qX-TCC"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="hcG-dV-pwK" firstAttribute="top" secondItem="NMj-Ey-DBa" secondAttribute="bottom" constant="40" id="2DI-sv-EOl"/>
+                <constraint firstItem="Nee-Hy-VgV" firstAttribute="top" secondItem="5SO-af-bAa" secondAttribute="bottom" constant="100" id="2DU-CU-kOH"/>
+                <constraint firstItem="9wH-qX-TCC" firstAttribute="trailing" secondItem="Nee-Hy-VgV" secondAttribute="trailing" constant="25" id="3V6-S3-RW0"/>
+                <constraint firstItem="5SO-af-bAa" firstAttribute="top" secondItem="cl7-AA-xVz" secondAttribute="bottom" constant="50" id="3k2-is-I1X"/>
                 <constraint firstItem="NMj-Ey-DBa" firstAttribute="top" secondItem="9wH-qX-TCC" secondAttribute="top" id="8u0-YO-74H"/>
-                <constraint firstItem="8KP-p7-85P" firstAttribute="top" secondItem="cl7-AA-xVz" secondAttribute="bottom" constant="46" id="IJ2-sH-pHI"/>
+                <constraint firstItem="cB6-s8-UVB" firstAttribute="top" secondItem="9wH-qX-TCC" secondAttribute="top" id="Af5-sY-zVi"/>
+                <constraint firstItem="5SO-af-bAa" firstAttribute="leading" secondItem="9wH-qX-TCC" secondAttribute="leading" constant="10" id="Esr-V5-X7E"/>
+                <constraint firstItem="Nee-Hy-VgV" firstAttribute="leading" secondItem="9wH-qX-TCC" secondAttribute="leading" constant="25" id="KKx-Of-Gak"/>
                 <constraint firstItem="hcG-dV-pwK" firstAttribute="leading" secondItem="9wH-qX-TCC" secondAttribute="leading" constant="10" id="XHL-Dl-EbW"/>
+                <constraint firstItem="Nee-Hy-VgV" firstAttribute="centerX" secondItem="9wH-qX-TCC" secondAttribute="centerX" id="XXc-d9-mJL"/>
                 <constraint firstItem="NMj-Ey-DBa" firstAttribute="width" secondItem="m8E-5B-yok" secondAttribute="width" multiplier="1:3" id="Z2h-KD-PBb"/>
                 <constraint firstItem="cl7-AA-xVz" firstAttribute="leading" secondItem="hcG-dV-pwK" secondAttribute="leading" id="b04-jf-h7f"/>
                 <constraint firstItem="9wH-qX-TCC" firstAttribute="trailing" secondItem="hcG-dV-pwK" secondAttribute="trailing" constant="10" id="ctS-GS-fX8"/>
-                <constraint firstItem="8KP-p7-85P" firstAttribute="leading" secondItem="9wH-qX-TCC" secondAttribute="leading" constant="10" id="dDz-ap-fVW"/>
+                <constraint firstItem="9wH-qX-TCC" firstAttribute="trailing" secondItem="5SO-af-bAa" secondAttribute="trailing" constant="10" id="hSY-lP-Yk6"/>
                 <constraint firstItem="cl7-AA-xVz" firstAttribute="top" secondItem="hcG-dV-pwK" secondAttribute="bottom" constant="25" id="qdd-BH-hgz"/>
+                <constraint firstItem="9wH-qX-TCC" firstAttribute="trailing" secondItem="cB6-s8-UVB" secondAttribute="trailing" constant="25" id="reb-4l-DgE"/>
                 <constraint firstItem="cl7-AA-xVz" firstAttribute="trailing" secondItem="hcG-dV-pwK" secondAttribute="trailing" id="rpv-oj-dVM"/>
                 <constraint firstItem="NMj-Ey-DBa" firstAttribute="centerX" secondItem="9wH-qX-TCC" secondAttribute="centerX" id="ver-0I-zyL"/>
             </constraints>

--- a/README.md
+++ b/README.md
@@ -44,13 +44,15 @@ Upon receiving an array of `ABKContentCard` objects from the SDK, the correspond
 
 Custom view controllers can represent in-app messages by subclassing `ABKInAppMessageViewController`. Due to the individusalitic nature of in-app messages, we can [mix and match](https://github.com/braze-inc/braze-growth-shares-ios-demo-app/blob/master/Braze-Demo/BrazeManager.swift#L155) displaying custom in-app messages and default in-app messages.
 
-### This demo highlights 3 in-app message use cases:
+### This demo highlights 4 in-app message use cases:
 1. Slideup In-App Message with a modified resting point
     - [SlideFromBottomViewController.swift](https://github.com/braze-inc/braze-growth-shares-ios-demo-app/blob/master/Braze-Demo/ViewController/In-App-Messages/SlideFromBottomViewController.swift)</br></br> 
 2. Modal In-App Message as a dynamic list
     - [ModalPickerViewController.swift](https://github.com/braze-inc/braze-growth-shares-ios-demo-app/blob/master/Braze-Demo/ViewController/In-App-Messages/ModalPickerViewController/ModalPickerViewController.swift)</br></br> 
-3. Full In-App Message as a push primer with list of push tags
-    - [FullListViewController.swift](https://github.com/braze-inc/braze-growth-shares-ios-demo-app/blob/master/Braze-Demo/ViewController/In-App-Messages/FullListViewController/FullListViewController.swift)</br></br> 
+3. Full In-App Message as a Push Notifications primer with list of push tags
+    - [FullListViewController.swift](https://github.com/braze-inc/braze-growth-shares-ios-demo-app/blob/master/Braze-Demo/ViewController/In-App-Messages/FullListViewController/FullListViewController.swift)</br></br>
+4. Full In-App Message as an interactive App Tracking Transparency primer
+    - [FullPermissionViewController.swift](https://github.com/braze-inc/braze-growth-shares-ios-demo-app/blob/master/Braze-Demo/ViewController/In-App-Messages/FullPermissionViewController/FullPermissionViewController.swift)</br></br>  
 
 ## Push Notifications
 


### PR DESCRIPTION
Created an example custom full view controller to showcase how a primer can be used for the new App Tracking Transparency permission prompt. 

Using the `view_type` KVP to determine which `ABKInAppMessageFullViewController` subclass to display. 


<img src=https://user-images.githubusercontent.com/5905170/117495726-a1f43700-af3b-11eb-9a8f-f897a8686cc5.png width=414 height=896>

https://user-images.githubusercontent.com/5905170/117496997-72462e80-af3d-11eb-8836-b3a51ed96b8d.mp4






