### PR TITLE
Added SharePlay capability to Video IAM

### DIFF
--- a/Braze-Demo.xcodeproj/project.pbxproj
+++ b/Braze-Demo.xcodeproj/project.pbxproj
@@ -1705,7 +1705,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Braze-Demo-LAB-Register-Content-Extension/Braze-Demo-LAB-Register-Content-Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5GLZKGNWQ3;
 				INFOPLIST_FILE = "Braze-Demo-LAB-Register-Content-Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
@@ -1731,7 +1731,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Braze-Demo-LAB-Register-Content-Extension/Braze-Demo-LAB-Register-Content-Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5GLZKGNWQ3;
 				INFOPLIST_FILE = "Braze-Demo-LAB-Register-Content-Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
@@ -1756,7 +1756,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5GLZKGNWQ3;
 				INFOPLIST_FILE = "Braze-Demo-Service-Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
@@ -1781,7 +1781,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5GLZKGNWQ3;
 				INFOPLIST_FILE = "Braze-Demo-Service-Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
@@ -1807,7 +1807,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Braze-Demo-Push-Story-Content-Extension/Braze-Demo-Push-Story-Content-Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5GLZKGNWQ3;
 				INFOPLIST_FILE = "Braze-Demo-Push-Story-Content-Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
@@ -1834,7 +1834,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Braze-Demo-Push-Story-Content-Extension/Braze-Demo-Push-Story-Content-Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5GLZKGNWQ3;
 				INFOPLIST_FILE = "Braze-Demo-Push-Story-Content-Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
@@ -1861,7 +1861,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Braze-Demo-Match-Game-Content-Extension/Braze-Demo-Match-Game-Content-Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5GLZKGNWQ3;
 				INFOPLIST_FILE = "Braze-Demo-Match-Game-Content-Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
@@ -1887,7 +1887,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Braze-Demo-Match-Game-Content-Extension/Braze-Demo-Match-Game-Content-Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5GLZKGNWQ3;
 				INFOPLIST_FILE = "Braze-Demo-Match-Game-Content-Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
@@ -2028,7 +2028,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Braze-Demo/SupportingFiles/Braze-Demo.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5GLZKGNWQ3;
 				INFOPLIST_FILE = "$(SRCROOT)/Braze-Demo/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
@@ -2055,7 +2055,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Braze-Demo/SupportingFiles/Braze-Demo.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5GLZKGNWQ3;
 				INFOPLIST_FILE = "$(SRCROOT)/Braze-Demo/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
@@ -2165,7 +2165,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Braze-Demo-LAB-Progress-Content-Extension/Braze-Demo-LAB-Progress-Content-Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5GLZKGNWQ3;
 				INFOPLIST_FILE = "Braze-Demo-LAB-Progress-Content-Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
@@ -2191,7 +2191,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Braze-Demo-LAB-Progress-Content-Extension/Braze-Demo-LAB-Progress-Content-Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5GLZKGNWQ3;
 				INFOPLIST_FILE = "Braze-Demo-LAB-Progress-Content-Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;

--- a/Braze-Demo.xcodeproj/project.pbxproj
+++ b/Braze-Demo.xcodeproj/project.pbxproj
@@ -44,8 +44,6 @@
 		7F1ADDA125E4199A00116E92 /* MatchCardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7F1ADDA025E4199A00116E92 /* MatchCardView.xib */; };
 		7F1ADDA825E41D3200116E92 /* UIVIew_Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FA45A3524C29131009A484B /* UIVIew_Util.swift */; };
 		7F384B4E256DC59300673410 /* InAppMessageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F384B4D256DC59300673410 /* InAppMessageData.swift */; };
-		7F3AAC3C26B8616700E9F774 /* AppboyUI in Frameworks */ = {isa = PBXBuildFile; productRef = 7F3AAC3B26B8616700E9F774 /* AppboyUI */; };
-		7F3AAC3E26B8616700E9F774 /* AppboyPushStory in Frameworks */ = {isa = PBXBuildFile; productRef = 7F3AAC3D26B8616700E9F774 /* AppboyPushStory */; };
 		7F3AAC4026B8621100E9F774 /* ModalVideoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3AAC3F26B8621100E9F774 /* ModalVideoViewController.swift */; };
 		7F3AAC4226B8621B00E9F774 /* ModalVideoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7F3AAC4126B8621B00E9F774 /* ModalVideoViewController.xib */; };
 		7F459F3426A0AA910084EC23 /* TextFieldEntryViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F459F3326A0AA910084EC23 /* TextFieldEntryViewCell.swift */; };
@@ -124,6 +122,9 @@
 		7FBDD4AE24AD711F00EC0983 /* BrazeDemoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FBDD4AD24AD711F00EC0983 /* BrazeDemoUITests.swift */; };
 		7FC3106624D1C29A00053D90 /* ContentCardGestureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC3106524D1C29A00053D90 /* ContentCardGestureView.swift */; };
 		7FC3106824D1C30100053D90 /* ContentCardGestureView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7FC3106724D1C30100053D90 /* ContentCardGestureView.xib */; };
+		7FC6D2F12703B00200513F82 /* AppboyPushStory in Frameworks */ = {isa = PBXBuildFile; productRef = 7FC6D2F02703B00200513F82 /* AppboyPushStory */; };
+		7FC6D2F32703B00200513F82 /* AppboyUI in Frameworks */ = {isa = PBXBuildFile; productRef = 7FC6D2F22703B00200513F82 /* AppboyUI */; };
+		7FC6D2F52703B11D00513F82 /* PlaybackCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC6D2F42703B11D00513F82 /* PlaybackCoordinator.swift */; };
 		7FCFB97924C2D184001AA381 /* Double_Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FCFB97824C2D184001AA381 /* Double_Util.swift */; };
 		7FCFB97B24C35EBA001AA381 /* ContentCardWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FCFB97A24C35EBA001AA381 /* ContentCardWebView.swift */; };
 		7FCFB97F24C35EE2001AA381 /* ContentCardWebView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7FCFB97E24C35EE2001AA381 /* ContentCardWebView.xib */; };
@@ -384,6 +385,7 @@
 		7FBDD4AF24AD711F00EC0983 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7FC3106524D1C29A00053D90 /* ContentCardGestureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardGestureView.swift; sourceTree = "<group>"; };
 		7FC3106724D1C30100053D90 /* ContentCardGestureView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ContentCardGestureView.xib; sourceTree = "<group>"; };
+		7FC6D2F42703B11D00513F82 /* PlaybackCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackCoordinator.swift; sourceTree = "<group>"; };
 		7FCFB97824C2D184001AA381 /* Double_Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double_Util.swift; sourceTree = "<group>"; };
 		7FCFB97A24C35EBA001AA381 /* ContentCardWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardWebView.swift; sourceTree = "<group>"; };
 		7FCFB97E24C35EE2001AA381 /* ContentCardWebView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ContentCardWebView.xib; sourceTree = "<group>"; };
@@ -473,7 +475,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7F8CB2EB25C888000001F270 /* UserNotificationsUI.framework in Frameworks */,
-				7F3AAC3E26B8616700E9F774 /* AppboyPushStory in Frameworks */,
+				7FC6D2F12703B00200513F82 /* AppboyPushStory in Frameworks */,
 				7F8CB2E925C888000001F270 /* UserNotifications.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -491,7 +493,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7F3AAC3C26B8616700E9F774 /* AppboyUI in Frameworks */,
+				7FC6D2F32703B00200513F82 /* AppboyUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -822,6 +824,7 @@
 				7F8FFC1924EC7EB50082C71B /* APIRequest.swift */,
 				7F8AF0132525353D006F478B /* API Requests */,
 				7FDBFE0926962E70000C1244 /* APIRequestBuilder.swift */,
+				7FC6D2F42703B11D00513F82 /* PlaybackCoordinator.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1142,7 +1145,7 @@
 			);
 			name = "Braze-Demo-Push-Story-Content-Extension";
 			packageProductDependencies = (
-				7F3AAC3D26B8616700E9F774 /* AppboyPushStory */,
+				7FC6D2F02703B00200513F82 /* AppboyPushStory */,
 			);
 			productName = "Braze Demo Content Extension";
 			productReference = 7F8CB2E625C888000001F270 /* Braze-Demo-Push-Story-Content-Extension.appex */;
@@ -1185,7 +1188,7 @@
 			);
 			name = "Braze-Demo";
 			packageProductDependencies = (
-				7F3AAC3B26B8616700E9F774 /* AppboyUI */,
+				7FC6D2F22703B00200513F82 /* AppboyUI */,
 			);
 			productName = BookDemo;
 			productReference = 7FBDD48524AD711E00EC0983 /* Braze-Demo.app */;
@@ -1292,7 +1295,7 @@
 			);
 			mainGroup = 7FBDD47C24AD711D00EC0983;
 			packageReferences = (
-				7F3AAC3A26B8616700E9F774 /* XCRemoteSwiftPackageReference "braze-ios-sdk" */,
+				7FC6D2EF2703B00200513F82 /* XCRemoteSwiftPackageReference "braze-ios-sdk" */,
 			);
 			productRefGroup = 7FBDD48624AD711E00EC0983 /* Products */;
 			projectDirPath = "";
@@ -1580,6 +1583,7 @@
 				7FCFB98D24C91421001AA381 /* Ad.swift in Sources */,
 				7F8967C625740F9900C61405 /* FullListViewController.swift in Sources */,
 				7F8FFC1A24EC7EB50082C71B /* APIRequest.swift in Sources */,
+				7FC6D2F52703B11D00513F82 /* PlaybackCoordinator.swift in Sources */,
 				7FDBFDDA268CDBB0000C1244 /* OutOfTheBoxContentCardsConfigurationViewController.swift in Sources */,
 				7F6C984A2564B08B000CDAAA /* HeadlineCollectionViewCell.swift in Sources */,
 				7FDFA26B24B68CA800E3B132 /* MessageCenterDataSource.swift in Sources */,
@@ -2293,26 +2297,26 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		7F3AAC3A26B8616700E9F774 /* XCRemoteSwiftPackageReference "braze-ios-sdk" */ = {
+		7FC6D2EF2703B00200513F82 /* XCRemoteSwiftPackageReference "braze-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/braze-inc/braze-ios-sdk.git";
+			repositoryURL = "https://github.com/braze-inc/braze-ios-sdk";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.3.1;
+				branch = master;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		7F3AAC3B26B8616700E9F774 /* AppboyUI */ = {
+		7FC6D2F02703B00200513F82 /* AppboyPushStory */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7F3AAC3A26B8616700E9F774 /* XCRemoteSwiftPackageReference "braze-ios-sdk" */;
-			productName = AppboyUI;
-		};
-		7F3AAC3D26B8616700E9F774 /* AppboyPushStory */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 7F3AAC3A26B8616700E9F774 /* XCRemoteSwiftPackageReference "braze-ios-sdk" */;
+			package = 7FC6D2EF2703B00200513F82 /* XCRemoteSwiftPackageReference "braze-ios-sdk" */;
 			productName = AppboyPushStory;
+		};
+		7FC6D2F22703B00200513F82 /* AppboyUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7FC6D2EF2703B00200513F82 /* XCRemoteSwiftPackageReference "braze-ios-sdk" */;
+			productName = AppboyUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/Braze-Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Braze-Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "Appboy_iOS_SDK",
-        "repositoryURL": "https://github.com/braze-inc/braze-ios-sdk.git",
+        "repositoryURL": "https://github.com/braze-inc/braze-ios-sdk",
         "state": {
-          "branch": null,
-          "revision": "e9075696dc2a0a6e0d7f510b7dc3836d101bfc4b",
-          "version": "4.3.1"
+          "branch": "master",
+          "revision": "0b4d513e45617b2347021d0b07a00f170819d988",
+          "version": null
         }
       },
       {

--- a/Braze-Demo/API/PlaybackCoordinator.swift
+++ b/Braze-Demo/API/PlaybackCoordinator.swift
@@ -2,7 +2,6 @@ import Foundation
 import Combine
 import GroupActivities
 import AVKit
-import AppboyUI
 
 @available(iOS 15.0, *)
 class PlaybackCoordinator {

--- a/Braze-Demo/API/PlaybackCoordinator.swift
+++ b/Braze-Demo/API/PlaybackCoordinator.swift
@@ -63,9 +63,8 @@ class PlaybackCoordinator {
       // If there's an active session, create an activity for the new selection.
       if groupSession.activity.mediaItem != selectedMediaItem {
         groupSession.activity = MediaItemActivity(mediaItem: selectedMediaItem)
-        }
-      } else {
-
+      }
+    } else {
         Task.init {
           // Create a new activity for the selected movie.
           let activity = MediaItemActivity(mediaItem: selectedMediaItem)
@@ -79,9 +78,9 @@ class PlaybackCoordinator {
             // The user prefers to share this activity with the group.
             // The app enqueues the movie for playback when the activity starts.
             do {
-                _ = try await activity.activate()
+              _ = try await activity.activate()
             } catch {
-                print("Unable to activate the activity: \(error)")
+              print("Unable to activate the activity: \(error)")
             }
           case .cancelled:
             // The user cancels the operation. Do nothing.

--- a/Braze-Demo/API/PlaybackCoordinator.swift
+++ b/Braze-Demo/API/PlaybackCoordinator.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Combine
+import GroupActivities
+import AVKit
+
+@available(iOS 15.0, *)
+class PlaybackCoordinator {
+  static let shared = PlaybackCoordinator()
+  private var subscriptions = Set<AnyCancellable>()
+  
+  private var selectedMediaItem: MediaItem? {
+    didSet {
+      // Ensure the UI selection always represents the currently playing media.
+      guard let _ = selectedMediaItem else { return }
+
+      BrazeManager.shared.logCustomEvent("Video Pressed")
+    }
+  }
+
+  // Published values that the player, and other UI items, observe.
+  @Published var enqueuedMediaItem: MediaItem?
+  @Published var groupSession: GroupSession<MediaItemActivity>?
+
+  private init() {
+    Task.init {
+
+      // Await new sessions to watch movies together.
+      for await groupSession in MediaItemActivity.sessions() {
+        // Set the app's active group session.
+        self.groupSession = groupSession
+
+        // Remove previous subscriptions.
+        subscriptions.removeAll()
+
+        // Observe changes to the session state.
+        groupSession.$state.sink { [weak self] state in
+          if case .invalidated = state {
+            // Set the groupSession to nil to publish
+            // the invalidated session state.
+            self?.groupSession = nil
+            self?.subscriptions.removeAll()
+          }
+        }.store(in: &subscriptions)
+
+        // Join the session to participate in playback coordination.
+        groupSession.join()
+
+        // Observe when the local user or a remote participant starts an activity.
+        groupSession.$activity.sink { [weak self] activity in
+          // Set the movie to enqueue it in the player.
+          self?.enqueuedMediaItem = activity.mediaItem
+        }.store(in: &subscriptions)
+      }
+    }
+  }
+
+  // Prepares the app to play the movie.
+  func prepareToPlay(_ selectedMediaItem: MediaItem) {
+    // Return early if the app enqueues the movie.
+    guard enqueuedMediaItem != selectedMediaItem else { return }
+
+    if let groupSession = groupSession {
+      // If there's an active session, create an activity for the new selection.
+      if groupSession.activity.mediaItem != selectedMediaItem {
+        groupSession.activity = MediaItemActivity(mediaItem: selectedMediaItem)
+        }
+      } else {
+
+        Task.init {
+          // Create a new activity for the selected movie.
+          let activity = MediaItemActivity(mediaItem: selectedMediaItem)
+          // Await the result of the preparation call.
+          switch await activity.prepareForActivation() {
+          case .activationDisabled:
+            // Playback coordination isn't active, or the user prefers to play the
+            // movie apart from the group. Enqueue the movie for local playback only.
+            self.enqueuedMediaItem = selectedMediaItem
+          case .activationPreferred:
+            // The user prefers to share this activity with the group.
+            // The app enqueues the movie for playback when the activity starts.
+            do {
+                _ = try await activity.activate()
+            } catch {
+                print("Unable to activate the activity: \(error)")
+            }
+          case .cancelled:
+            // The user cancels the operation. Do nothing.
+            break
+          default: ()
+        }
+      }
+    }
+  }
+
+  // Launch a video from SharePlay if enqueued.
+  func launchVideoPlayerIfNecessary() {
+    PlaybackCoordinator.shared.$enqueuedMediaItem
+      .receive(on: DispatchQueue.main)
+      .compactMap { $0 }
+      .assign(to: \.selectedMediaItem, on: self)
+      .store(in: &subscriptions)
+  }
+}
+
+struct MediaItem: Hashable, Codable {
+  let title: String
+  let url: URL
+}
+
+@available(iOS 15, *)
+struct MediaItemActivity: GroupActivity {
+  static let activityIdentifier = "com.book-demo.GroupWatching"
+
+  let mediaItem: MediaItem
+
+  var metadata: GroupActivityMetadata {
+    var metadata = GroupActivityMetadata()
+    metadata.type = .watchTogether
+    metadata.title = mediaItem.title
+    metadata.fallbackURL = mediaItem.url
+    return metadata
+  }
+}
+
+struct InterruptionResult {
+  let type: AVAudioSession.InterruptionType
+  let options: AVAudioSession.InterruptionOptions
+
+  init?(_ notification: Notification) {
+    // Determine the interruption type and options.
+    guard let type = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? AVAudioSession.InterruptionType,
+    let options = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? AVAudioSession.InterruptionOptions else {
+      return nil
+    }
+
+    self.type = type
+    self.options = options
+  }
+}

--- a/Braze-Demo/API/PlaybackCoordinator.swift
+++ b/Braze-Demo/API/PlaybackCoordinator.swift
@@ -2,6 +2,8 @@ import Foundation
 import Combine
 import GroupActivities
 import AVKit
+import AppboyKit
+import AppboyUI
 
 @available(iOS 15.0, *)
 class PlaybackCoordinator {
@@ -14,8 +16,9 @@ class PlaybackCoordinator {
       // Ensure the UI selection always represents the currently playing media.
       guard let _ = selectedMediaItem else { return }
 
-      BrazeManager.shared.logCustomEvent("Video Pressed")
-      mediaItemSubscriptions.removeAll()
+      if !BrazeManager.shared.inAppMessageCurrentlyVisible {
+        BrazeManager.shared.logCustomEvent("Video Pressed")
+      }
     }
   }
 
@@ -55,7 +58,11 @@ class PlaybackCoordinator {
       }
     }
   }
+}
 
+// MARK: - Public Methods
+@available(iOS 15.0, *)
+extension PlaybackCoordinator {
   // Prepares the app to play the movie.
   func prepareToPlay(_ selectedMediaItem: MediaItem) {
     // Return early if the app enqueues the movie.
@@ -100,6 +107,12 @@ class PlaybackCoordinator {
       .compactMap { $0 }
       .assign(to: \.selectedMediaItem, on: self)
       .store(in: &mediaItemSubscriptions)
+  }
+  
+  // Clear activity when user leaves
+  func leave() {
+    groupSession = nil
+    enqueuedMediaItem = nil
   }
 }
 

--- a/Braze-Demo/API/PlaybackCoordinator.swift
+++ b/Braze-Demo/API/PlaybackCoordinator.swift
@@ -2,7 +2,6 @@ import Foundation
 import Combine
 import GroupActivities
 import AVKit
-import AppboyKit
 import AppboyUI
 
 @available(iOS 15.0, *)

--- a/Braze-Demo/BrazeManager.swift
+++ b/Braze-Demo/BrazeManager.swift
@@ -355,11 +355,7 @@ private extension BrazeManager {
     case InAppMessageViewType.picker.rawValue:
       return ModalPickerViewController(inAppMessage: inAppMessage)
     case InAppMessageViewType.video.rawValue:
-      if #available(iOS 15.0, *) {
-        return ModalVideoViewController(inAppMessage: inAppMessage)
-      } else {
-        return ABKInAppMessageModalViewController(inAppMessage: inAppMessage)
-      }
+      return ModalVideoViewController(inAppMessage: inAppMessage)
     default:
       return ABKInAppMessageModalViewController(inAppMessage: inAppMessage)
     }

--- a/Braze-Demo/BrazeManager.swift
+++ b/Braze-Demo/BrazeManager.swift
@@ -172,6 +172,10 @@ extension BrazeManager: ABKInAppMessageUIDelegate {
       return ABKInAppMessageViewController(inAppMessage: inAppMessage)
     }
   }
+  
+  var inAppMessageCurrentlyVisible: Bool {
+    return Appboy.sharedInstance()?.inAppMessageController.inAppMessageUIController?.inAppMessageCurrentlyVisible?() ?? false
+  }
 }
 
 // MARK: - Content Cards

--- a/Braze-Demo/BrazeManager.swift
+++ b/Braze-Demo/BrazeManager.swift
@@ -35,6 +35,11 @@ class BrazeManager: NSObject {
     logPendingCustomEventsIfNecessary()
     logPendingCustomAttributesIfNecessary()
     logPendingUserAttributesIfNecessary()
+    
+    // MARK: - SharePlay
+    if #available(iOS 15, *) {
+      PlaybackCoordinator.shared.launchVideoPlayerIfNecessary()
+    }
   }
   
   /// Initialized as the value for the ABKIDFADelegateKey.
@@ -350,7 +355,11 @@ private extension BrazeManager {
     case InAppMessageViewType.picker.rawValue:
       return ModalPickerViewController(inAppMessage: inAppMessage)
     case InAppMessageViewType.video.rawValue:
-      return ModalVideoViewController(inAppMessage: inAppMessage)
+      if #available(iOS 15.0, *) {
+        return ModalVideoViewController(inAppMessage: inAppMessage)
+      } else {
+        return ABKInAppMessageModalViewController(inAppMessage: inAppMessage)
+      }
     default:
       return ABKInAppMessageModalViewController(inAppMessage: inAppMessage)
     }

--- a/Braze-Demo/SupportingFiles/Braze-Demo.entitlements
+++ b/Braze-Demo/SupportingFiles/Braze-Demo.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.group-session</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.braze.book-demo</string>

--- a/Braze-Demo/ViewController/In-App-Messages/ModalVideoViewController/ModalVideoViewController.swift
+++ b/Braze-Demo/ViewController/In-App-Messages/ModalVideoViewController/ModalVideoViewController.swift
@@ -1,21 +1,50 @@
 import UIKit
+import Combine
+import GroupActivities
 import AVKit
 
+@available(iOS 15, *)
 class ModalVideoViewController: ModalViewController {
   
   // MARK: - Outlets
   @IBOutlet private weak var videoPlayerContainer: UIView!
+  @IBOutlet private weak var sharePlayButton: UIButton!
+  
+  // MARK: - Actions
+  @IBAction func sharePlayButtonPressed(_ sender: UIButton) {
+    guard let mediaItem = mediaItem else { return }
+    PlaybackCoordinator.shared.prepareToPlay(mediaItem)
+  }
   
   // MARK: - Variables
   private let playerViewController = AVPlayerViewController()
+  private let player = AVPlayer()
+  private let groupStateObserver = GroupStateObserver()
+  private var subscriptions = Set<AnyCancellable>()
+  private var mediaItem: MediaItem?
+  private var isEligibleForSharePlay: Bool = false {
+      didSet {
+        sharePlayButton.isHidden = !isEligibleForSharePlay
+      }
+    }
+  
+  // The group session to coordinate playback with.
+  private var groupSession: GroupSession<MediaItemActivity>? {
+    didSet {
+      guard let session = groupSession else {
+        // Stop playback if a session terminates.
+        player.rate = 0
+        return
+      }
+      // Coordinate playback with the active session.
+      player.playbackCoordinator.coordinateWithSession(session)
+    }
+  }
   
   override var nibName: String {
     return "ModalVideoViewController"
   }
-}
-
-// MARK: - View Lifecycle
-extension ModalVideoViewController {
+  
   /// Overriding loadView() from ABKInAppMessageModalViewController to provide our own view for the In-App Message
   override func loadView() {
     Bundle.main.loadNibNamed(nibName, owner: self, options: nil)
@@ -25,6 +54,7 @@ extension ModalVideoViewController {
     super.viewDidLoad()
     
     configureVideoPlayer()
+    configureSharePlay()
   }
   
   override func viewWillAppear(_ animated: Bool) {
@@ -35,22 +65,72 @@ extension ModalVideoViewController {
   override func viewDidLayoutSubviews() {
     configureVideoPlayerFrame()
   }
+  
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    groupSession?.leave()
+  }
 }
 
 // MARK: - Private
+@available(iOS 15, *)
 private extension ModalVideoViewController {
   func configureVideoPlayer() {
     guard let urlString = inAppMessage.extras?["video_url"] as? String,
           let url = URL(string: urlString) else { return }
     
+    let videoTitle = inAppMessage.extras?["video_title"] as? String
+    mediaItem = MediaItem(title: videoTitle ?? "Video Content", url: url)
+    
     let asset = AVAsset(url: url)
     let playerItem = AVPlayerItem(asset: asset)
-    let player = AVPlayer(playerItem: playerItem)
+    player.replaceCurrentItem(with: playerItem)
     playerViewController.player = player
     
     addChild(playerViewController)
     videoPlayerContainer.addSubview(playerViewController.view)
     playerViewController.didMove(toParent: self)
+  }
+  
+  func configureSharePlay() {
+    // SharePlay button eligibility
+    groupStateObserver.$isEligibleForGroupSession
+      .receive(on: DispatchQueue.main)
+      .assign(to: \.isEligibleForSharePlay, on: self)
+      .store(in: &subscriptions)
+
+    // The movie subscriber.
+    PlaybackCoordinator.shared.$enqueuedMediaItem
+      .receive(on: DispatchQueue.main)
+      .compactMap { $0 }
+      .assign(to: \.mediaItem, on: self)
+      .store(in: &subscriptions)
+
+    // The group session subscriber.
+    PlaybackCoordinator.shared.$groupSession
+      .receive(on: DispatchQueue.main)
+      .assign(to: \.groupSession, on: self)
+      .store(in: &subscriptions)
+
+    player.publisher(for: \.timeControlStatus, options: [.initial])
+      .receive(on: DispatchQueue.main)
+      .sink { _ in }
+      .store(in: &subscriptions)
+    
+    // Observe audio session interruptions.
+    NotificationCenter.default
+      .publisher(for: AVAudioSession.interruptionNotification)
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] notification in
+
+        // Wrap the notification in helper type that extracts the interruption type and options.
+        guard let result = InterruptionResult(notification) else { return }
+
+        // Resume playback, if appropriate.
+        if result.type == .ended && result.options == .shouldResume {
+          self?.player.play()
+        }
+    }.store(in: &subscriptions)
   }
   
   /// Set the `AVPlayerViewController`'s  frame to the`videoPlayerContainer`'s bounds explicitly set the .xib file. Only update the value if the two are not equal.

--- a/Braze-Demo/ViewController/In-App-Messages/ModalVideoViewController/ModalVideoViewController.swift
+++ b/Braze-Demo/ViewController/In-App-Messages/ModalVideoViewController/ModalVideoViewController.swift
@@ -66,6 +66,7 @@ class ModalVideoViewController: ModalViewController {
     
     if #available(iOS 15.0, *) {
       groupVideoPlayer.session?.leave()
+      PlaybackCoordinator.shared.leave()
     }
   }
 }

--- a/Braze-Demo/ViewController/In-App-Messages/ModalVideoViewController/ModalVideoViewController.swift
+++ b/Braze-Demo/ViewController/In-App-Messages/ModalVideoViewController/ModalVideoViewController.swift
@@ -18,7 +18,7 @@ class ModalVideoViewController: ModalViewController {
   
   // MARK: - Variables
   @available(iOS 15.0, *)
-  private(set) lazy var groupStateObserver = GroupStateObserver()
+  private lazy var groupStateObserver = GroupStateObserver()
   @available(iOS 15.0, *)
   fileprivate lazy var groupVideoPlayer = GroupVideoPlayer(player: player)
   

--- a/Braze-Demo/ViewController/In-App-Messages/ModalVideoViewController/ModalVideoViewController.xib
+++ b/Braze-Demo/ViewController/In-App-Messages/ModalVideoViewController/ModalVideoViewController.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,6 +13,7 @@
             <connections>
                 <outlet property="inAppMessageHeaderLabel" destination="dDg-pF-Mt9" id="E4f-gg-Rar"/>
                 <outlet property="inAppMessageMessageLabel" destination="X7v-sq-cbU" id="lxm-ie-i9D"/>
+                <outlet property="sharePlayButton" destination="j2Y-Ir-jzr" id="yln-GN-1Zw"/>
                 <outlet property="videoPlayerContainer" destination="bk2-yW-Fx9" id="Mle-qc-CeK"/>
                 <outlet property="view" destination="6BP-OF-PV1" id="ibb-q0-QOH"/>
             </connections>
@@ -52,11 +54,20 @@
                         <action selector="dismissInAppMessage:" destination="-1" eventType="touchUpInside" id="KOG-aQ-Gxh"/>
                     </connections>
                 </button>
+                <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j2Y-Ir-jzr">
+                    <rect key="frame" x="7" y="0.0" width="58.5" height="31"/>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" image="shareplay" catalog="system" title=" "/>
+                    <connections>
+                        <action selector="sharePlayButtonPressed:" destination="-1" eventType="touchUpInside" id="f1X-HK-wFh"/>
+                    </connections>
+                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="rz2-UM-V9i"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="bk2-yW-Fx9" firstAttribute="leading" secondItem="rz2-UM-V9i" secondAttribute="leading" id="2dw-tz-R1x"/>
+                <constraint firstItem="j2Y-Ir-jzr" firstAttribute="top" secondItem="9ol-un-5OB" secondAttribute="top" id="3Vf-iV-KWg"/>
                 <constraint firstItem="dDg-pF-Mt9" firstAttribute="top" secondItem="6BP-OF-PV1" secondAttribute="top" constant="40" id="Egi-Ld-qVM"/>
                 <constraint firstItem="dDg-pF-Mt9" firstAttribute="leading" secondItem="rz2-UM-V9i" secondAttribute="leading" constant="10" id="HoC-eZ-NxI"/>
                 <constraint firstItem="rz2-UM-V9i" firstAttribute="bottom" secondItem="bk2-yW-Fx9" secondAttribute="bottom" id="K2R-EX-ag5"/>
@@ -64,6 +75,7 @@
                 <constraint firstItem="9ol-un-5OB" firstAttribute="top" secondItem="6BP-OF-PV1" secondAttribute="top" id="QgT-do-XZb"/>
                 <constraint firstItem="rz2-UM-V9i" firstAttribute="trailing" secondItem="bk2-yW-Fx9" secondAttribute="trailing" id="VWw-5J-86x"/>
                 <constraint firstItem="X7v-sq-cbU" firstAttribute="centerX" secondItem="dDg-pF-Mt9" secondAttribute="centerX" id="gFA-Pg-Be7"/>
+                <constraint firstItem="j2Y-Ir-jzr" firstAttribute="leading" secondItem="rz2-UM-V9i" secondAttribute="leading" constant="7" id="pYM-S3-Vdh"/>
                 <constraint firstItem="X7v-sq-cbU" firstAttribute="trailing" secondItem="dDg-pF-Mt9" secondAttribute="trailing" id="qpW-eb-EIh"/>
                 <constraint firstItem="rz2-UM-V9i" firstAttribute="trailing" secondItem="dDg-pF-Mt9" secondAttribute="trailing" constant="15" id="rhE-0I-I8h"/>
                 <constraint firstItem="X7v-sq-cbU" firstAttribute="top" secondItem="dDg-pF-Mt9" secondAttribute="bottom" constant="15" id="rld-re-uhT"/>
@@ -82,6 +94,7 @@
         </view>
     </objects>
     <resources>
+        <image name="shareplay" catalog="system" width="128" height="73"/>
         <image name="xmark" catalog="system" width="128" height="113"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
Beefed up the Video IAM to support SharePlay capability - made possible with the help of [Apple's Demo Project](https://developer.apple.com/documentation/avfoundation/media_playback_and_selection/supporting_coordinated_media_playback)

**To Test**
SharePlay is not available on iOS 15.0 but is available on the iOS 15.1 beta

For iOS 15 users who are eligible to start SharePlay (on a FaceTime call), they will see the SharePlay button appear on the Modal IAM to kick off a group session. 

Users on below iOS 14 can still interact with the IAM but the SharePlay button will not be visible. 

**How it works (high-level)**
- 1st user receives IAM
- 1st user starts SharePlay
- 2nd user taps "Open SharePlay" button
- `PlaybackCoordinator` manages group session for 2nd user on app launch and triggers custom even to launch the video IAM
- SharePlay begins


**Pausing playback**
![image5](https://user-images.githubusercontent.com/5905170/135328974-b1786844-bf05-4004-ac8c-61d489088aa3.png)
![image2](https://user-images.githubusercontent.com/5905170/135328976-d58d658c-43de-4f77-96b9-5df86fdc094a.png)

**iOS 14 users**
![Simulator Screen Shot - iPhone 12 Pro Max - 2021-09-29 at 14 35 21](https://user-images.githubusercontent.com/5905170/135329029-f5a57362-e60d-4add-aa0d-e0a099a19e65.png)