### PR TITLE
Refactored HomeData for API Layer

### DIFF
--- a/Braze-Demo.xcodeproj/project.pbxproj
+++ b/Braze-Demo.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		7F754FC3250C2F8000CD7B45 /* RemoteStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F754FC2250C2F8000CD7B45 /* RemoteStorage.swift */; };
 		7F754FC5250C3A5200CD7B45 /* String_Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F754FC4250C3A5200CD7B45 /* String_Util.swift */; };
 		7F754FC7250C436000CD7B45 /* MessageCenterContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F754FC6250C435F00CD7B45 /* MessageCenterContainerViewController.swift */; };
+		7F7FE75C2769274B00BFCAD7 /* NetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7FE75B2769274B00BFCAD7 /* NetworkRequest.swift */; };
 		7F87D4AA24B0500200ED0A86 /* BrazeSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F87D4A924B0500200ED0A86 /* BrazeSettingsViewController.swift */; };
 		7F87D4AC24B2709400ED0A86 /* ShoppingCartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F87D4AB24B2709400ED0A86 /* ShoppingCartViewController.swift */; };
 		7F87D4AE24B2A24B00ED0A86 /* TextField_Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F87D4AD24B2A24B00ED0A86 /* TextField_Util.swift */; };
@@ -331,6 +332,7 @@
 		7F754FC2250C2F8000CD7B45 /* RemoteStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteStorage.swift; sourceTree = "<group>"; };
 		7F754FC4250C3A5200CD7B45 /* String_Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String_Util.swift; sourceTree = "<group>"; };
 		7F754FC6250C435F00CD7B45 /* MessageCenterContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCenterContainerViewController.swift; sourceTree = "<group>"; };
+		7F7FE75B2769274B00BFCAD7 /* NetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequest.swift; sourceTree = "<group>"; };
 		7F87D4A924B0500200ED0A86 /* BrazeSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrazeSettingsViewController.swift; sourceTree = "<group>"; };
 		7F87D4AB24B2709400ED0A86 /* ShoppingCartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingCartViewController.swift; sourceTree = "<group>"; };
 		7F87D4AD24B2A24B00ED0A86 /* TextField_Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextField_Util.swift; sourceTree = "<group>"; };
@@ -385,7 +387,7 @@
 		7FBDD48C24AD711E00EC0983 /* HomeListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeListViewController.swift; sourceTree = "<group>"; };
 		7FBDD49224AD711E00EC0983 /* BookDemo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = BookDemo.xcdatamodel; sourceTree = "<group>"; };
 		7FBDD49424AD711F00EC0983 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		7FBDD49924AD711F00EC0983 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Info.plist; sourceTree = "<group>"; };
+		7FBDD49924AD711F00EC0983 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = "Braze-Demo/Info.plist"; sourceTree = SOURCE_ROOT; };
 		7FBDD49E24AD711F00EC0983 /* Braze-DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Braze-DemoTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7FBDD4A224AD711F00EC0983 /* BrazeDemoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrazeDemoTests.swift; sourceTree = "<group>"; };
 		7FBDD4A424AD711F00EC0983 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -826,6 +828,7 @@
 				7F8AF0132525353D006F478B /* API Requests */,
 				7FDBFE0926962E70000C1244 /* APIRequestBuilder.swift */,
 				7FC6D2F42703B11D00513F82 /* PlaybackCoordinator.swift */,
+				7F7FE75B2769274B00BFCAD7 /* NetworkRequest.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1555,6 +1558,7 @@
 				7FDBFE052690B2A2000C1244 /* FontConfigurationView.swift in Sources */,
 				7FBDD49324AD711E00EC0983 /* Braze-Demo.xcdatamodeld in Sources */,
 				7FBDD48924AD711E00EC0983 /* AppDelegate.swift in Sources */,
+				7F7FE75C2769274B00BFCAD7 /* NetworkRequest.swift in Sources */,
 				7FF1ADBA24C0B67400AF09F0 /* MessageCenterDetailViewController.swift in Sources */,
 				7FDBFDFB268E6C8C000C1244 /* CustomClassicContentCardCell.swift in Sources */,
 				7F6C980B25643EAA000CDAAA /* CollectionViewDataSourceProvider.swift in Sources */,

--- a/Braze-Demo/API/ContentOperationQueue.swift
+++ b/Braze-Demo/API/ContentOperationQueue.swift
@@ -34,22 +34,7 @@ extension ContentOperationQueue {
     var meta: HomeMetaData = await loadMetaData()
     
     contentCardCompletionHandler = { contentCards in
-      for card in contentCards {
-        switch card.contentCardData?.contentCardClassType {
-        case .home(.pill):
-          meta.data[0].attributes.pills += [card as! HomeItem]
-        case .home(.bottle):
-          meta.data[0].attributes.bottles += [card as! HomeItem]
-        case .home(.miniBottle):
-          let miniBottle = card as! HomeItem
-          for i in 0..<meta.data[0].attributes.composites.count {
-            if meta.data[0].attributes.composites[i].compositeID == miniBottle.compositeID {
-              meta.data[0].attributes.composites[i].miniBottles.append(miniBottle)
-            }
-          }
-        default: break
-        }
-      }
+      self.formatContentCards(contentCards, toData: &meta.data)
     }
     
     addOperation { [weak self] in
@@ -75,6 +60,25 @@ private extension ContentOperationQueue {
       return try await NetworkRequest.makeRequest()
     } catch {
       return HomeMetaData.empty
+    }
+  }
+  
+  func formatContentCards(_ cards: [ContentCardable], toData data: inout HomeData) {
+    for card in cards {
+      switch card.contentCardData?.contentCardClassType {
+      case .home(.pill):
+        data.attributes.pills.append(card as! HomeItem)
+      case .home(.bottle):
+        data.attributes.bottles.append(card as! HomeItem)
+      case .home(.miniBottle):
+        let miniBottle = card as! HomeItem
+        for i in 0..<data.attributes.composites.count {
+          if data.attributes.composites[i].compositeID == miniBottle.compositeID {
+            data.attributes.composites[i].miniBottles.append(miniBottle)
+          }
+        }
+      default: continue
+      }
     }
   }
 }

--- a/Braze-Demo/API/ContentOperationQueue.swift
+++ b/Braze-Demo/API/ContentOperationQueue.swift
@@ -57,7 +57,7 @@ extension ContentOperationQueue {
 private extension ContentOperationQueue {
   func loadMetaData() async -> HomeMetaData {
     do {
-      return try await NetworkRequest.makeRequest(string: "https://run.mocky.io/v3/6a11c26a-9b9e-4811-90b9-e97f98f55d5a")
+      return try await NetworkRequest.makeRequest(string: "https://masquerade.k8s.tools-001.p-use-1.braze.com/api/configs/1?populate=attributes,header,pills,bottles,composites.mini_bottles,attributes.config_icon,pills.image,bottles.image,composites.mini_bottles.image")
     } catch {
       return HomeMetaData.empty
     }

--- a/Braze-Demo/API/ContentOperationQueue.swift
+++ b/Braze-Demo/API/ContentOperationQueue.swift
@@ -57,7 +57,7 @@ extension ContentOperationQueue {
 private extension ContentOperationQueue {
   func loadMetaData() async -> HomeMetaData {
     do {
-      return try await NetworkRequest.makeRequest()
+      return try await NetworkRequest.makeRequest(string: "https://run.mocky.io/v3/6a11c26a-9b9e-4811-90b9-e97f98f55d5a")
     } catch {
       return HomeMetaData.empty
     }

--- a/Braze-Demo/API/NetworkRequest.swift
+++ b/Braze-Demo/API/NetworkRequest.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum NetworkRequestError: Error {
+  case invalidUrl
+  case invalidJson(String)
+}
+
+class NetworkRequest<T: Codable>: NSObject {
+  static func makeRequest() async throws -> T {
+    guard let url = URL(string: "https://run.mocky.io/v3/cca73fc8-2121-4be2-9a80-80aa51419f19") else {
+      throw NetworkRequestError.invalidUrl
+    }
+
+    do {
+      let (data, _) = try await URLSession.shared.data(from: url)
+      let result = try JSONDecoder().decode(T.self, from: data)
+      return result
+    } catch {
+      throw NetworkRequestError.invalidJson(error.localizedDescription)
+    }
+  }
+}

--- a/Braze-Demo/API/NetworkRequest.swift
+++ b/Braze-Demo/API/NetworkRequest.swift
@@ -6,8 +6,8 @@ enum NetworkRequestError: Error {
 }
 
 class NetworkRequest<T: Codable>: NSObject {
-  static func makeRequest() async throws -> T {
-    guard let url = URL(string: "https://run.mocky.io/v3/6a11c26a-9b9e-4811-90b9-e97f98f55d5a") else {
+  static func makeRequest(string: String) async throws -> T {
+    guard let url = URL(string: string) else {
       throw NetworkRequestError.invalidUrl
     }
 

--- a/Braze-Demo/API/NetworkRequest.swift
+++ b/Braze-Demo/API/NetworkRequest.swift
@@ -7,7 +7,7 @@ enum NetworkRequestError: Error {
 
 class NetworkRequest<T: Codable>: NSObject {
   static func makeRequest() async throws -> T {
-    guard let url = URL(string: "https://run.mocky.io/v3/cca73fc8-2121-4be2-9a80-80aa51419f19") else {
+    guard let url = URL(string: "https://run.mocky.io/v3/6a11c26a-9b9e-4811-90b9-e97f98f55d5a") else {
       throw NetworkRequestError.invalidUrl
     }
 

--- a/Braze-Demo/BrazeManager.swift
+++ b/Braze-Demo/BrazeManager.swift
@@ -303,13 +303,13 @@ private extension BrazeManager {
     case .coupon:
       return Coupon(metaData: metaData, classType: classType)
     case .home(.bottle):
-      return Bottle(metaData: metaData, classType: classType)
+      return HomeItem(metaData: metaData, classType: classType)
     case .home(.group):
       return Group(metaData: metaData, classType: classType)
     case .home(.miniBottle):
-      return MiniBottle(metaData: metaData, classType: classType)
+      return HomeItem(metaData: metaData, classType: classType)
     case .home(.pill):
-      return Pill(metaData: metaData, classType: classType)
+      return HomeItem(metaData: metaData, classType: classType)
     case .home(.tile):
       return Tile(metaData: metaData, classType: classType)
     case .message(.fullPage):

--- a/Braze-Demo/SwiftUI/BottleView.swift
+++ b/Braze-Demo/SwiftUI/BottleView.swift
@@ -34,6 +34,6 @@ struct BottleView_Previews: PreviewProvider {
   }
   
   static var previews: some View {
-    BottleView(bottle: HomeItem(contentCardData: nil, id: 0, title: "LOREM", eventName: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: nil, compositeID: nil))
+    BottleView(bottle: HomeItem(contentCardData: nil, id: 0, title: "LOREM", eventName: nil, image: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: nil, compositeID: nil))
   }
 }

--- a/Braze-Demo/SwiftUI/BottleView.swift
+++ b/Braze-Demo/SwiftUI/BottleView.swift
@@ -1,24 +1,23 @@
 import SwiftUI
 
 struct BottleView: View {
-  var title: String
-  var url: URL?
+  var bottle: HomeItem
   
   var body: some View {
     ZStack {
-      AsyncImage(url: url, content: { image in
+      AsyncImage(url: bottle.imageUrl, content: { image in
         image
           .renderingMode(.original)
           .resizable()
           .opacity(0.8)
       }, placeholder: {
-        Color.clear
+        bottle.backgroundColor
       })
       
       VStack {
         Spacer()
-        Text(title)
-          .foregroundColor(.white)
+        Text(bottle.title)
+          .foregroundColor(bottle.fontColor)
           .font(.title3)
           .fontWeight(.bold)
           .padding(.vertical)
@@ -30,11 +29,11 @@ struct BottleView: View {
 }
 
 struct BottleView_Previews: PreviewProvider {
-  static var url: URL? {
-    return URL(string: "https://i.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+  static var imageUrlString: String {
+    return "https://i.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI"
   }
   
   static var previews: some View {
-    BottleView(title: "Bottle", url: url)
+    BottleView(bottle: HomeItem(contentCardData: nil, id: 0, title: "LOREM", eventName: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: nil, compositeID: nil))
   }
 }

--- a/Braze-Demo/SwiftUI/CompositeView.swift
+++ b/Braze-Demo/SwiftUI/CompositeView.swift
@@ -38,7 +38,7 @@ struct CompositeView: View {
 
 struct HomeDetailView_Previews: PreviewProvider {
   static var miniBottle: HomeItem {
-    return HomeItem(contentCardData: nil, id: 0, title: "LOREM", eventName: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: "#000000", compositeID: 0)
+    return HomeItem(contentCardData: nil, id: 0, title: "LOREM", eventName: nil, image: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: "#000000", compositeID: 0)
   }
   
   static var imageUrlString: String {

--- a/Braze-Demo/SwiftUI/CompositeView.swift
+++ b/Braze-Demo/SwiftUI/CompositeView.swift
@@ -1,26 +1,26 @@
 import SwiftUI
 
 struct CompositeView: View {
-  var title: String
-  var subtitle: String
-  var miniBottles: [MiniBottle]
+  var composite: Composite
   
   var body: some View {
     ZStack {
       VStack(alignment: .leading) {
-        Text(title)
+        Text(composite.title)
+          .foregroundColor(composite.fontColor)
           .font(.title3)
           .fontWeight(.bold)
           .padding(.horizontal)
           
-        Text(subtitle)
+        Text(composite.subtitle)
+          .foregroundColor(composite.fontColor)
           .font(.body)
           .padding(.horizontal)
          
         ScrollView(.horizontal, showsIndicators: false) {
           HStack(spacing: 10) {
-            ForEach(miniBottles, id: \.self) { bottle in
-              MiniBottleView(title: bottle.title, url: bottle.imageUrl)
+            ForEach(composite.miniBottles, id: \.self) { miniBottle in
+              MiniBottleView(miniBottle: miniBottle)
             }
           }
           .padding(.horizontal)
@@ -31,17 +31,22 @@ struct CompositeView: View {
     }
     .padding(.top)
     .padding(.bottom)
-    .background(Color(red: 242 / 255, green: 242 / 255, blue: 242 / 255))
+    .background(composite.backgroundColor)
     .cornerRadius(15)
   }
 }
 
 struct HomeDetailView_Previews: PreviewProvider {
+  static var miniBottle: HomeItem {
+    return HomeItem(contentCardData: nil, id: 0, title: "LOREM", eventName: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: "#000000", compositeID: 0)
+  }
+  
   static var imageUrlString: String {
     return "https://i.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI"
   }
   
   static var previews: some View {
-    CompositeView(title: "Lorem", subtitle: "Ipsum", miniBottles: [MiniBottle(compositeId: 0, title: "Bottle", imageUrlString: imageUrlString), MiniBottle(compositeId: 0, title: "Bottle", imageUrlString: imageUrlString), MiniBottle(compositeId: 0, title: "Bottle", imageUrlString: imageUrlString), MiniBottle(compositeId: 0, title: "Bottle", imageUrlString: imageUrlString)])
+    
+    CompositeView(composite: Composite(id: 0, title: "LOREM", subtitle: "IPSUM", fontColorString: "#000000", backgroundColorString: "#FFFFFF", compositeID: 0, miniBottles: [miniBottle, miniBottle, miniBottle, miniBottle]))
   }
 }

--- a/Braze-Demo/SwiftUI/HomeView.swift
+++ b/Braze-Demo/SwiftUI/HomeView.swift
@@ -9,20 +9,21 @@ struct HomeView: View {
         ScrollView(.horizontal, showsIndicators: false) {
           HStack(spacing: 10) {
             ForEach(viewModel.pills, id: \.self) { pill in
-              PillView(title: pill.title, url: pill.imageUrl)
+              PillView(pill: pill)
             }
           }
           .padding()
         }
         
-        Text("Braze LAB Courses")
+        Text(viewModel.header.title)
+          .foregroundColor(viewModel.header.fontColor)
           .font(.body)
           .padding(.horizontal)
         
         ScrollView(.horizontal, showsIndicators: false) {
           HStack(spacing: 10) {
             ForEach(viewModel.bottles, id: \.self) { bottle in
-              BottleView(title: bottle.title, url: bottle.imageUrl)
+              BottleView(bottle: bottle)
             }
           }
           .padding(.horizontal)
@@ -31,7 +32,7 @@ struct HomeView: View {
         
         VStack(spacing: 20) {
           ForEach(viewModel.composites, id: \.self) { composite in
-            CompositeView(title: composite.title, subtitle: composite.subtitle, miniBottles: composite.miniBottles)
+            CompositeView(composite: composite)
           }
         }
         .padding(.horizontal)

--- a/Braze-Demo/SwiftUI/HomeViewModel.swift
+++ b/Braze-Demo/SwiftUI/HomeViewModel.swift
@@ -3,57 +3,30 @@ import Combine
 
 @MainActor
 final class HomeViewModel: NSObject, ObservableObject {
-  @Published var data: HomeData?
+  @Published var meta: HomeMetaData = HomeMetaData.empty
   
   func requestHomeData() async {
-    self.data = await ContentOperationQueue(classTypes: [.home(.pill), .home(.bottle), .home(.miniBottle)]).downloadContent()
+    self.meta = await ContentOperationQueue(classTypes: [.home(.pill), .home(.bottle), .home(.miniBottle)]).downloadContent()
   }
   
-  var pills: [Pill] {
-    return data?.pills ?? []
+  var header: Header {
+    return  meta.data.first!.attributes.header
   }
   
-  var bottles: [Bottle] {
-    return data?.bottles ?? []
+  var pills: [HomeItem] {
+    return meta.data.first!.attributes.pills
+  }
+  
+  var bottles: [HomeItem] {
+    return  meta.data.first!.attributes.bottles
   }
   
   var composites: [Composite] {
-    return data?.composites ?? []
+    return  meta.data.first!.attributes.composites
   }
-}
-
-protocol HomeItem: ContentCardable, Codable {
-  var title: String { get }
-  var imageUrlString: String { get }
 }
 
 extension HomeItem {
-  var imageUrl: URL? {
-    return URL(string: imageUrlString)
-  }
-}
-
-struct HomeData: Codable {
-  var pills: [Pill]
-  var bottles: [Bottle]
-  var composites: [Composite]
-}
-
-struct Pill: HomeItem, Hashable {
-  private(set) var contentCardData: ContentCardData?
-  private(set) var title: String
-  private(set) var imageUrlString: String
-  
-  let eventName: String?
-  
-  private enum CodingKeys: String, CodingKey {
-    case title
-    case imageUrlString = "image"
-    case eventName = "event_name"
-  }
-}
-
-extension Pill {
   init?(metaData: [ContentCardKey : Any], classType contentCardClassType: ContentCardClassType) {
     guard let idString = metaData[.idString] as? String,
           let createdAt = metaData[.created] as? Double,
@@ -63,75 +36,135 @@ extension Pill {
           let extras = metaData[.extras] as? [AnyHashable: Any]
     else { return nil }
     
-    let eventName = extras[ContentCardKey.eventName.rawValue] as? String
-    
     let contentCardData = ContentCardData(contentCardId: idString, contentCardClassType: contentCardClassType, createdAt: createdAt, isDismissible: isDismissible)
+   
+    var compositeID: Int?
+    if let compositeIDString = extras[ContentCardKey.compositeId.rawValue] as? String {
+      compositeID = Int(compositeIDString)
+    }
     
-    self.init(contentCardData: contentCardData, title: title, imageUrlString: imageUrlString, eventName: eventName)
+    self.init(contentCardData: contentCardData, id: 0, title: title, eventName: "", imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: "#000000", compositeID: compositeID)
   }
 }
 
-struct Composite: Codable, Hashable {
+// MARK: - HomeMetaData
+struct HomeMetaData: Codable {
+  var data: [HomeData]
+}
+
+extension HomeMetaData {
+  static var empty: HomeMetaData {
+    return HomeMetaData(data: [HomeData(id: -1, attributes: HomeAttributes(createdAt: "", updatedAt: "", publishedAt: "", configuration: HomeConfiguration(id: -1, apiKey: "", configTitle: "", attributesDescription: "", configIcon: "", vertical: ""), header: Header(id: -1, title: "", fontColorString: nil, backgroundColorString: nil), pills: [], bottles: [], composites: []))])
+  }
+}
+
+// MARK: - HomeData
+struct HomeData: Codable {
+  let id: Int
+  var attributes: HomeAttributes
+}
+
+// MARK: - HomeAttributes
+struct HomeAttributes: Codable {
+  let createdAt, updatedAt, publishedAt: String
+  let configuration: HomeConfiguration
+  let header: Header
+  var pills, bottles: [HomeItem]
+  var composites: [Composite]
+  
+  enum CodingKeys: String, CodingKey {
+    case createdAt, updatedAt, publishedAt, header, pills, bottles, composites
+    case configuration = "attributes"
+  }
+}
+
+// MARK: - HomeConfiguration
+struct HomeConfiguration: Codable {
+  let id: Int
+  let apiKey, configTitle, attributesDescription: String
+  let configIcon: String
+  let vertical: String
+
+  enum CodingKeys: String, CodingKey {
+    case id, vertical
+    case apiKey = "api_key"
+    case configTitle = "config_title"
+    case attributesDescription = "description"
+    case configIcon = "config_icon"
+  }
+}
+
+// MARK: - HomeItem
+struct HomeItem: ContentCardable, Codable, Hashable, HomeColorable, HomeImageable {
+  private(set) var contentCardData: ContentCardData?
   let id: Int
   let title: String
-  let subtitle: String
-  var miniBottles: [MiniBottle]
-}
+  let eventName: String?
+  private(set) var imageUrlString: String?
+  private(set) var fontColorString, backgroundColorString: String?
+  let compositeID: Int?
 
-struct Bottle: HomeItem, Hashable {
-  private(set) var contentCardData: ContentCardData?
-  private(set) var title: String
-  private(set) var imageUrlString: String
-  
-  private enum CodingKeys: String, CodingKey {
-    case title
+  enum CodingKeys: String, CodingKey {
+    case id, title
     case imageUrlString = "image"
+    case eventName = "event_name"
+    case backgroundColorString = "background_color"
+    case fontColorString = "font_color"
+    case compositeID = "composite_id"
   }
 }
 
-extension Bottle {
-  init?(metaData: [ContentCardKey : Any], classType contentCardClassType: ContentCardClassType) {
-    guard let idString = metaData[.idString] as? String,
-          let createdAt = metaData[.created] as? Double,
-          let isDismissible = metaData[.dismissible] as? Bool,
-          let title = metaData[.title] as? String,
-          let imageUrlString = metaData[.image] as? String
-    else { return nil }
-    
-    let contentCardData = ContentCardData(contentCardId: idString, contentCardClassType: contentCardClassType, createdAt: createdAt, isDismissible: isDismissible)
-    
-    self.init(contentCardData: contentCardData, title: title, imageUrlString: imageUrlString)
+protocol HomeImageable {
+  var imageUrlString: String? { get }
+}
+
+extension HomeImageable {
+  var imageUrl: URL? {
+    guard let imageUrlString = imageUrlString else { return nil }
+    return URL(string: imageUrlString)
   }
 }
 
-struct MiniBottle: HomeItem, Hashable {
-  let compositeId: Int
-  private(set) var contentCardData: ContentCardData?
-  private(set) var title: String
-  private(set) var imageUrlString: String
+protocol HomeColorable {
+  var fontColorString: String? { get }
+  var backgroundColorString: String? { get}
+}
+
+extension HomeColorable {
+  var fontColor: Color {
+    return Color(fontColorString?.colorValue() ?? .black)
+  }
   
-  private enum CodingKeys: String, CodingKey {
-    case compositeId = "composite_id"
-    case title
-    case imageUrlString = "image"
+  var backgroundColor: Color {
+    return Color(backgroundColorString?.colorValue() ?? .white)
   }
 }
 
-extension MiniBottle {
-  init?(metaData: [ContentCardKey : Any], classType contentCardClassType: ContentCardClassType) {
-    guard let idString = metaData[.idString] as? String,
-          let createdAt = metaData[.created] as? Double,
-          let isDismissible = metaData[.dismissible] as? Bool,
-          let title = metaData[.title] as? String,
-          let imageUrlString = metaData[.image] as? String,
-          let extras = metaData[.extras] as? [AnyHashable: Any],
-          let compositeIdString = extras[ContentCardKey.compositeId.rawValue] as? String,
-          let compositeId = Int(compositeIdString)
-    else { return nil }
-    
-    let contentCardData = ContentCardData(contentCardId: idString, contentCardClassType: contentCardClassType, createdAt: createdAt, isDismissible: isDismissible)
-    
-    self.init(compositeId: compositeId, contentCardData: contentCardData, title: title, imageUrlString: imageUrlString)
+// MARK: - Composite
+struct Composite: Codable, Hashable, HomeColorable {
+  let id: Int
+  let title, subtitle: String
+  private(set) var fontColorString, backgroundColorString: String?
+  let compositeID: Int
+  var miniBottles: [HomeItem]
+
+  enum CodingKeys: String, CodingKey {
+    case id, title, subtitle
+    case fontColorString = "font_color"
+    case backgroundColorString = "background_color"
+    case compositeID = "composite_id"
+    case miniBottles = "mini_bottles"
   }
 }
 
+// MARK: - Header
+struct Header: Codable, HomeColorable {
+  let id: Int
+  let title: String
+  private(set) var fontColorString, backgroundColorString: String?
+
+  enum CodingKeys: String, CodingKey {
+    case id, title
+    case fontColorString = "font_color"
+  }
+}

--- a/Braze-Demo/SwiftUI/HomeViewModel.swift
+++ b/Braze-Demo/SwiftUI/HomeViewModel.swift
@@ -43,7 +43,7 @@ extension HomeItem {
       compositeID = Int(compositeIDString)
     }
     
-    self.init(contentCardData: contentCardData, id: 0, title: title, eventName: "", imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: "#000000", compositeID: compositeID)
+    self.init(contentCardData: contentCardData, id: 0, title: title, eventName: "", image: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: "#000000", compositeID: compositeID)
   }
 }
 
@@ -54,7 +54,7 @@ struct HomeMetaData: Codable {
 
 extension HomeMetaData {
   static var empty: HomeMetaData {
-    return HomeMetaData(data: HomeData(id: -1, attributes: HomeAttributes(createdAt: "", updatedAt: "", publishedAt: "", configuration: HomeConfiguration(id: -1, apiKey: "", configTitle: "", attributesDescription: "", configIcon: "", vertical: ""), header: Header(id: -1, title: "", fontColorString: nil, backgroundColorString: nil), pills: [], bottles: [], composites: [])))
+    return HomeMetaData(data: HomeData(id: -1, attributes: HomeAttributes(createdAt: "", updatedAt: "", publishedAt: "", configuration: HomeConfiguration(id: -1, apiKey: "", configTitle: "", attributesDescription: "", vertical: ""), header: Header(id: -1, title: "", fontColorString: nil, backgroundColorString: nil), pills: [], bottles: [], composites: [])))
   }
 }
 
@@ -82,7 +82,6 @@ struct HomeAttributes: Codable {
 struct HomeConfiguration: Codable {
   let id: Int
   let apiKey, configTitle, attributesDescription: String
-  let configIcon: String
   let vertical: String
 
   enum CodingKeys: String, CodingKey {
@@ -90,23 +89,22 @@ struct HomeConfiguration: Codable {
     case apiKey = "api_key"
     case configTitle = "config_title"
     case attributesDescription = "description"
-    case configIcon = "config_icon"
   }
 }
 
 // MARK: - HomeItem
-struct HomeItem: ContentCardable, Codable, Hashable, HomeColorable, HomeImageable {
+struct HomeItem: ContentCardable, Codable, Hashable, HomeColorable {
   private(set) var contentCardData: ContentCardData?
   let id: Int
   let title: String
   let eventName: String?
+  let image: ImageMetaData?
   private(set) var imageUrlString: String?
   private(set) var fontColorString, backgroundColorString: String?
   let compositeID: Int?
 
   enum CodingKeys: String, CodingKey {
-    case id, title
-    case imageUrlString = "image"
+    case id, title, image
     case eventName = "event_name"
     case backgroundColorString = "background_color"
     case fontColorString = "font_color"
@@ -114,14 +112,38 @@ struct HomeItem: ContentCardable, Codable, Hashable, HomeColorable, HomeImageabl
   }
 }
 
-protocol HomeImageable {
-  var imageUrlString: String? { get }
+extension HomeItem {
+  var imageUrl: URL? {
+    if let urlString = image?.data.attributes.url {
+      let domain = "https://masquerade.k8s.tools-001.p-use-1.braze.com"
+      return URL(string: domain + urlString)
+    } else if let urlString = imageUrlString {
+      return URL(string: urlString)
+    } else {
+      return nil
+    }
+  }
 }
 
-extension HomeImageable {
-  var imageUrl: URL? {
-    guard let imageUrlString = imageUrlString else { return nil }
-    return URL(string: imageUrlString)
+// MARK: - Image
+struct ImageMetaData: Codable, Hashable {
+  let data: ImageData
+}
+
+// MARK: - ImageData
+struct ImageData: Codable, Hashable  {
+  let id: Int
+  let attributes: ImageAttributes
+}
+
+// MARK: - ImageAttributes
+struct ImageAttributes: Codable, Hashable {
+  let url: String
+  let previewURL: String?
+
+  enum CodingKeys: String, CodingKey {
+    case url
+    case previewURL = "previewUrl"
   }
 }
 

--- a/Braze-Demo/SwiftUI/HomeViewModel.swift
+++ b/Braze-Demo/SwiftUI/HomeViewModel.swift
@@ -10,19 +10,19 @@ final class HomeViewModel: NSObject, ObservableObject {
   }
   
   var header: Header {
-    return  meta.data.first!.attributes.header
+    return  meta.data.attributes.header
   }
   
   var pills: [HomeItem] {
-    return meta.data.first!.attributes.pills
+    return meta.data.attributes.pills
   }
   
   var bottles: [HomeItem] {
-    return  meta.data.first!.attributes.bottles
+    return  meta.data.attributes.bottles
   }
   
   var composites: [Composite] {
-    return  meta.data.first!.attributes.composites
+    return  meta.data.attributes.composites
   }
 }
 
@@ -49,12 +49,12 @@ extension HomeItem {
 
 // MARK: - HomeMetaData
 struct HomeMetaData: Codable {
-  var data: [HomeData]
+  var data: HomeData
 }
 
 extension HomeMetaData {
   static var empty: HomeMetaData {
-    return HomeMetaData(data: [HomeData(id: -1, attributes: HomeAttributes(createdAt: "", updatedAt: "", publishedAt: "", configuration: HomeConfiguration(id: -1, apiKey: "", configTitle: "", attributesDescription: "", configIcon: "", vertical: ""), header: Header(id: -1, title: "", fontColorString: nil, backgroundColorString: nil), pills: [], bottles: [], composites: []))])
+    return HomeMetaData(data: HomeData(id: -1, attributes: HomeAttributes(createdAt: "", updatedAt: "", publishedAt: "", configuration: HomeConfiguration(id: -1, apiKey: "", configTitle: "", attributesDescription: "", configIcon: "", vertical: ""), header: Header(id: -1, title: "", fontColorString: nil, backgroundColorString: nil), pills: [], bottles: [], composites: [])))
   }
 }
 

--- a/Braze-Demo/SwiftUI/MiniBottleView.swift
+++ b/Braze-Demo/SwiftUI/MiniBottleView.swift
@@ -1,23 +1,22 @@
 import SwiftUI
 
 struct MiniBottleView: View {
-  var title: String
-  var url: URL?
+  var miniBottle: HomeItem
   
   var body: some View {
     ZStack {
-      AsyncImage(url: url, content: { image in
+      AsyncImage(url: miniBottle.imageUrl, content: { image in
         image
           .renderingMode(.original)
           .resizable()
           .opacity(0.8)
       }, placeholder: {
-        Color.clear
+        miniBottle.backgroundColor
       })
       
       VStack {
-        Text(title)
-          .foregroundColor(.white)
+        Text(miniBottle.title)
+          .foregroundColor(miniBottle.fontColor)
           .font(.body)
           .fontWeight(.bold)
           .multilineTextAlignment(.center)
@@ -30,11 +29,11 @@ struct MiniBottleView: View {
 }
 
 struct MiniBottleView_Previews: PreviewProvider {
-  static var url: URL? {
-    return URL(string: "https://i.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+  static var imageUrlString: String {
+    "https://i.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI"
   }
   
     static var previews: some View {
-      MiniBottleView(title: "Mini Bottle Grande Bottle Mini Bottle", url: url)
+      MiniBottleView(miniBottle: HomeItem(contentCardData: nil, id: 0, title: "LOREM", eventName: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: "#000000", compositeID: 0))
     }
 }

--- a/Braze-Demo/SwiftUI/MiniBottleView.swift
+++ b/Braze-Demo/SwiftUI/MiniBottleView.swift
@@ -34,6 +34,6 @@ struct MiniBottleView_Previews: PreviewProvider {
   }
   
     static var previews: some View {
-      MiniBottleView(miniBottle: HomeItem(contentCardData: nil, id: 0, title: "LOREM", eventName: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: "#000000", compositeID: 0))
+      MiniBottleView(miniBottle: HomeItem(contentCardData: nil, id: 0, title: "LOREM", eventName: nil, image: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: "#000000", compositeID: 0))
     }
 }

--- a/Braze-Demo/SwiftUI/PillView.swift
+++ b/Braze-Demo/SwiftUI/PillView.swift
@@ -1,22 +1,21 @@
 import SwiftUI
 
 struct PillView: View {
-  var title: String
-  var url: URL?
+  var pill: HomeItem
   
   var body: some View {
     ZStack {
-      AsyncImage(url: url, content: { image in
+      AsyncImage(url: pill.imageUrl, content: { image in
         image
           .renderingMode(.original)
           .resizable()
           .opacity(0.8)
       }, placeholder: {
-        Color.clear
+        pill.backgroundColor
       })
       
-      Text(title)
-        .foregroundColor(.white)
+      Text(pill.title)
+        .foregroundColor(pill.fontColor)
         .font(.title3)
         .fontWeight(.bold)
     }
@@ -26,11 +25,11 @@ struct PillView: View {
 }
 
 struct PillView_Previews: PreviewProvider {
-  static var url: URL? {
-    return URL(string: "https://i.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+  static var imageUrlString: String {
+    return "https://i.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI"
   }
   
   static var previews: some View {
-    PillView(title: "PILL", url: url)
+    PillView(pill: HomeItem(contentCardData: nil, id: 0, title: "LOREM", eventName: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: "#000000", compositeID: nil))
   }
 }

--- a/Braze-Demo/SwiftUI/PillView.swift
+++ b/Braze-Demo/SwiftUI/PillView.swift
@@ -30,6 +30,6 @@ struct PillView_Previews: PreviewProvider {
   }
   
   static var previews: some View {
-    PillView(pill: HomeItem(contentCardData: nil, id: 0, title: "LOREM", eventName: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: "#000000", compositeID: nil))
+    PillView(pill: HomeItem(contentCardData: nil, id: 0, title: "LOREM", eventName: nil, image: nil, imageUrlString: imageUrlString, fontColorString: "#FFFFFF", backgroundColorString: "#000000", compositeID: nil))
   }
 }


### PR DESCRIPTION
- Refactored `HomeData` to include the proper fields and structure based on the JSON structure (currently using a [mocky](https://run.mocky.io/v3/6a11c26a-9b9e-4811-90b9-e97f98f55d5a) endpoint to simulate)

- Home Screen now hits an endpoint instead of loading local JSON data from the app bundle

- Refactored SwiftUI views to accept Models instead of primitive types